### PR TITLE
Nonexhaustive variants and more derives

### DIFF
--- a/src/twitch/badge.rs
+++ b/src/twitch/badge.rs
@@ -2,7 +2,7 @@
 ///
 /// Any unknown (e.g. custom badges/sub events, etc) are placed into the
 /// `Unknown` variant
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BadgeKind {
     /// Admin badge
@@ -32,7 +32,7 @@ pub enum BadgeKind {
 }
 
 /// Badges attached to a message
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Badge {
     /// The kind of Badge

--- a/src/twitch/badge.rs
+++ b/src/twitch/badge.rs
@@ -29,6 +29,9 @@ pub enum BadgeKind {
     Partner,
     /// An Unknown badge
     Unknown(String),
+    // Reserve the right to add more fields to this enum
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Badges attached to a message
@@ -39,7 +42,7 @@ pub struct Badge {
     pub kind: BadgeKind,
     /// Any associated data with the badge
     ///
-    /// May be the version, the number of bits, the number of months in a substreak
+    /// May be the version, the number of bits, the number of months needed for the subscriber badge, etc.
     pub data: String,
 }
 

--- a/src/twitch/capability.rs
+++ b/src/twitch/capability.rs
@@ -22,6 +22,9 @@ pub enum Capability {
     ///
     /// Provides metadata attached to each message
     Tags,
+    // Reserve the right to add more fields to this enum
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Capability {
@@ -31,6 +34,7 @@ impl Capability {
             Capability::Membership => Some("CAP REQ :twitch.tv/membership"),
             Capability::Commands => Some("CAP REQ :twitch.tv/commands"),
             Capability::Tags => Some("CAP REQ :twitch.tv/tags"),
+            Capability::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/twitch/capability.rs
+++ b/src/twitch/capability.rs
@@ -3,7 +3,7 @@
 /// The default, `generic` is very simplistic (basically just read/write PRIVMSGs for a channel)
 ///
 /// While enabling `membership` + `commands` + `tags` will allow you to get a much more rich set of messages
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Capability {
     /// Generic capability, the default.

--- a/src/twitch/channel.rs
+++ b/src/twitch/channel.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Simple channel wrapper.
 ///
 /// This ensures the twitch channels align with IRC naming scheme.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Channel(String);
 

--- a/src/twitch/color.rs
+++ b/src/twitch/color.rs
@@ -165,6 +165,7 @@ impl std::fmt::Display for Color {
             SpringGreen => "SpringGreen",
             YellowGreen => "YellowGreen",
             Turbo => return write!(f, "{}", self.rgb.to_string()),
+            __Nonexhaustive => unreachable!(),
         };
         write!(f, "{}", name)
     }
@@ -250,6 +251,8 @@ pub enum TwitchColor {
     YellowGreen,
     /// Turbo colors are custom user-selected colors
     Turbo,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl From<RGB> for Color {

--- a/src/twitch/color.rs
+++ b/src/twitch/color.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 /// An error returned from the FromStr impls of RGB and Color
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ColorError {
     /// An invalid Hex string for `RGB`
     InvalidHexString,
@@ -20,7 +20,7 @@ impl std::fmt::Display for ColorError {
 impl std::error::Error for ColorError {}
 
 /// A 24-bit triplet for hex colors. Defaults to *White* `(0xFF,0xFF,0xFF)`
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct RGB(pub u8, pub u8, pub u8);
 
 impl RGB {
@@ -136,7 +136,7 @@ impl FromStr for RGB {
 /// SpringGreen |`#00FF7F`| springgreen, spring_green, spring green
 /// YellowGreen |`#ADFF2F`| yellowgreen, yellow_green, yellow green
 /// Turbo |*custom*| ---
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     /// The name of the Twitch color
@@ -215,7 +215,7 @@ impl FromStr for Color {
 }
 
 /// These are the default Twitch colors
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TwitchColor {
     /// RGB (hex): #0000FF

--- a/src/twitch/emotes.rs
+++ b/src/twitch/emotes.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 ///
 /// `"testing Kappa"` would be `25:8-13`
 /// `"Kappa testing Kappa"` would be `25:0-5,14-19`
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Emotes {
     /// The emote id, e.g. `Kappa = 25`

--- a/src/twitch/filter.rs
+++ b/src/twitch/filter.rs
@@ -108,6 +108,9 @@ pub enum Filter {
     UserNotice,
     UserState,
     GlobalUserState,
+    // Reserve the right to add more fields to this enum
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 pub trait MessageFilter {
@@ -135,6 +138,7 @@ impl Message {
             Message::UserState { .. } => UserState,
             Message::GlobalUserState { .. } => GlobalUserState,
             Message::Irc { .. } => Irc,
+            Message::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/twitch/handler.rs
+++ b/src/twitch/handler.rs
@@ -58,6 +58,7 @@ impl Handlers {
             Message::UserNotice(msg) => dispatch!(msg, on_user_notice),
             Message::UserState(msg) => dispatch!(msg, on_user_state),
             Message::GlobalUserState(msg) => dispatch!(msg, on_global_user_state),
+            Message::__Nonexhaustive => unreachable!(),
         };
 
         dispatch!(msg, on_message)

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -99,6 +99,9 @@ pub enum Message {
     UserState(commands::UserState),
     /// On successful login.
     GlobalUserState(commands::GlobalUserState),
+    // Reserve the right to add more fields to this enum
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 pub(crate) mod filter;

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -113,7 +113,7 @@ pub use handler::Handler;
 /// This is used in both the simple filters ([`Client::on`](./struct.Client.html#method.on) and [`Client::off`](./struct.Client.html#method.off))
 ///
 /// and in the more flexible handler system ([`Client::handler`](./struct.Client.html#method.handler), [`Client::remove_handler`](./struct.Client.html#method.remove_handler))
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Token(pub(super) usize);
 
 impl std::fmt::Display for Token {


### PR DESCRIPTION
Touches #27 and adds some missing derives.

 
Some remaining topics.

* Add extensible field to [`commands`](https://github.com/museun/twitchchat/tree/7399088b937c0ce41c63cfc8e1681d73c497486a/src/twitch/commands)
* Do some other enums/structs need this?