### PR TITLE
Add badge-info

### DIFF
--- a/src/twitch/badge.rs
+++ b/src/twitch/badge.rs
@@ -68,3 +68,6 @@ impl Badge {
         })
     }
 }
+
+/// Metadata related to the chat badges.
+pub type BadgeInfo = Badge;

--- a/src/twitch/commands/mod.rs
+++ b/src/twitch/commands/mod.rs
@@ -33,7 +33,7 @@ pub use self::usernotice::{NoticeType, SubPlan, UserNotice};
 pub use self::userstate::UserState;
 
 use crate::irc::types::*;
-use crate::twitch::{Badge, Color, Emotes, RGB};
+use crate::twitch::{Badge, BadgeInfo, Color, Emotes, RGB};
 
 /// Tag allows access to the Tags part of the Message
 pub trait Tag {

--- a/src/twitch/commands/privmsg.rs
+++ b/src/twitch/commands/privmsg.rs
@@ -36,6 +36,12 @@ impl PrivMsg {
 }
 
 impl PrivMsg {
+    /// Metadata related to the chat badges
+    ///
+    /// Currently used only for `subscriber`, to indicate the exact number of months the user has been a subscriber.
+    pub fn badge_info(&self) -> Vec<BadgeInfo> {
+        badges(self.get("badge-info").unwrap_or_default())
+    }
     /// List of badges attached to the user/message
     pub fn badges(&self) -> Vec<Badge> {
         badges(self.get("badges").unwrap_or_default())

--- a/src/twitch/commands/usernotice.rs
+++ b/src/twitch/commands/usernotice.rs
@@ -24,6 +24,12 @@ impl UserNotice {
 }
 
 impl UserNotice {
+    /// Metadata related to the chat badges
+    ///
+    /// Currently used only for `subscriber`, to indicate the exact number of months the user has been a subscriber.
+    pub fn badge_info(&self) -> Vec<BadgeInfo> {
+        badges(self.get("badge-info").unwrap_or_default())
+    }
     /// List of badges attached to this message
     pub fn badges(&self) -> Vec<Badge> {
         badges(self.get("badges").unwrap_or_default())

--- a/src/twitch/commands/userstate.rs
+++ b/src/twitch/commands/userstate.rs
@@ -18,6 +18,13 @@ impl UserState {
 }
 
 impl UserState {
+    /// Metadata related to the chat badges
+    ///
+    /// Currently used only for `subscriber`, to indicate the exact number of months the user has been a subscriber.
+    pub fn badge_info(&self) -> Vec<BadgeInfo> {
+        badges(self.get("badge-info").unwrap_or_default())
+    }
+
     /// Badges attached to this message
     pub fn badges(&self) -> Vec<Badge> {
         badges(self.get("badges").unwrap_or_default())

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -4,7 +4,7 @@ mod emotes;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub use self::badge::{Badge, BadgeKind};
+pub use self::badge::{Badge, BadgeInfo, BadgeKind};
 pub use self::emotes::Emotes;
 
 pub use self::color::{twitch_colors as colors, Color, TwitchColor, RGB};


### PR DESCRIPTION
Twitch has to say this about the tag
> Metadata related to the chat badges in the badges tag.
>
> Currently this is used only for subscriber, to indicate the exact number of months the user has been a subscriber. This number is finer grained than the version number in badges. For example, a user who has been a subscriber for 45 months would have a badge-info value of 45 but might have a badges version number for only 3 years.

Example: `@badge-info=subscriber/13;badges=subscriber/12;color=#0000FF;display-name=emilgardis;emote-sets=0;mod=0;subscriber=1;user-type= :tmi.twitch.tv USERSTATE #jtv`

