### PR TITLE
Fix badge on Crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [ "twitch", "irc" ]
 license = "0BSD"
 
 [badges]
-circle-ci = { repository = "https://github.com/museun/twitchchat", branch = "master" }
+circle-ci = { repository = "museun/twitchchat", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]


### PR DESCRIPTION
URL of the Circle CI badge on crates.io was https://circleci.com/gh/https://github.com/museun/twitchchat instead of https://circleci.com/gh/museun/twitchchat

I assume this is also the reason the badge doesn't show on Crates.io, and that this change will fix the badge and url.

According to the [cargo book](https://doc.rust-lang.org/cargo/reference/manifest.html) the service key is optional since it's a github repo