### PR TITLE
Change Writer::whisper to use impl Trait

### DIFF
--- a/src/twitch/writer.rs
+++ b/src/twitch/writer.rs
@@ -325,10 +325,7 @@ impl Writer {
     }
 
     /// Whispers the message to the username.
-    pub fn whisper<S>(&self, username: S, message: S) -> Result<(), Error>
-    where
-        S: Display,
-    {
+    pub fn whisper(&self, username: impl Display, message: impl Display) -> Result<(), Error> {
         self.command(format!("/w {} {}", username, message))
     }
 


### PR DESCRIPTION
This fixes an issue when two distinct types that implements `Display` is
used for username and message.

This could also be solved with `S1,S2` etc but this felt more natural. This could also be done to all `S: Display` constraints. If that is wanted I could also add that to this pr.