### PR TITLE
Rework borrowed/shared types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.3.0"
 optional = true
 
 [dependencies.futures]
-version = "0.3.1"
+version = "0.3.2"
 optional = true
 default-features = false
 features = ["alloc"] # for AbortHandle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ futures    = { version = "0.3", optional = true, default-features = false, featu
 log        = { version = "0.4" }
 native-tls = { version = "0.2", optional = true }
 serde      = { version = "1",   optional = true, features = ["derive"] }
-tokio      = { version = "0.2", optional = true, default-features = false, features = ["dns", "stream", "sync", "tcp"] }
+tokio      = { version = "0.2", optional = true, default-features = false, features = ["dns", "stream", "sync", "tcp", "time"] }
 tokio-tls  = { version = "0.3", optional = true }
 
 [dev-dependencies]
 matches = "0.1"
-tokio   = { version = "0.2", default-features = false, features = ["dns", "io-util", "macros", "stream", "sync", "tcp"] }
+tokio   = { version = "0.2", default-features = false, features = ["dns", "io-util", "macros", "stream", "sync", "tcp", "time", "test-util" ] }
 
 [[example]]
 name = "demo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,58 +1,36 @@
 [package]
-name = "twitchchat"
-edition = "2018"
-version = "0.8.0-beta.4"
-authors = ["museun <museun@outlook.com>"]
-keywords = ["twitch", "irc", "async", "asynchronous", "tokio"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-description = "interface to the irc-side of twitch's chat system"
-repository = "https://github.com/museun/twitchchat"
+name          = "twitchchat"
+edition       = "2018"
+version       = "0.8.0-beta.4"
+authors       = ["museun <museun@outlook.com>"]
+keywords      = ["twitch", "irc", "async", "asynchronous", "tokio"]
+license       = "MIT OR Apache-2.0"
+readme        = "README.md"
+description   = "interface to the irc-side of twitch's chat system"
+documentation = "https://docs.rs/twitchchat/0.8.0-beta.4/twitchchat/"
+repository    = "https://github.com/museun/twitchchat"
+categories    = ["asynchronous", "network-programming", "parser-implementations"]
 
 [package.metadata.docs.rs]
-features = ["default", "serde"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["async", "tls"]
-async = ["tokio", "futures"]
-tls = ["tokio-tls", "native-tls"]
+async   = ["tokio", "futures"]
+tls     = ["tokio-tls", "native-tls"]
 
 [dependencies]
-log = "0.4.8"
-
-[dependencies.tokio]
-version = "0.2.11"
-optional = true
-default-features = false
-features = ["dns", "stream", "sync", "tcp"]
-
-[dependencies.tokio-tls]
-version = "0.3.0"
-optional = true
-
-[dependencies.futures]
-version = "0.3.2"
-optional = true
-default-features = false
-features = ["alloc"] # for AbortHandle
-
-[dependencies.native-tls]
-version = "0.2.3"
-optional = true
-
-[dependencies.serde]
-version = "1.0.104"
-optional = true
-features = ["derive"]
+futures    = { version = "0.3", optional = true, default-features = false, features = ["alloc"] } # for AbortHandle
+log        = { version = "0.4" }
+native-tls = { version = "0.2", optional = true }
+serde      = { version = "1",   optional = true, features = ["derive"] }
+tokio      = { version = "0.2", optional = true, default-features = false, features = ["dns", "stream", "sync", "tcp"] }
+tokio-tls  = { version = "0.3", optional = true }
 
 [dev-dependencies]
-matches = "0.1.8"
-flexi_logger = "0.14.6"
-
-[dev-dependencies.tokio]
-version = "0.2.11"
-default-features = false
-features = ["dns", "io-util", "macros", "stream", "sync", "tcp", "time"]
+matches = "0.1"
+tokio   = { version = "0.2", default-features = false, features = ["dns", "io-util", "macros", "stream", "sync", "tcp"] }
 
 [[example]]
 name = "demo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,10 @@ tokio   = { version = "0.2", default-features = false, features = ["dns", "io-ut
 [[example]]
 name = "demo"
 required-features = ["async"]
+
+[[example]]
+name = "short"
+required-features = ["async"]
+
+[[example]]
+name = "parse"

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,0 +1,57 @@
+use twitchchat::messages::*;
+use twitchchat::{AsOwned as _, Parse as _};
+
+fn main() {
+    let input = "@badge-info=subscriber/8;color=#59517B;tmi-sent-ts=1580932171144;user-type= :tmi.twitch.tv USERNOTICE #justinfan1234\r\n";
+
+    // parse potentionally many messages from the input (flatten just safely unwraps the result)
+    // msg is a decode::Message<'a> here
+    for msg in twitchchat::decode(&input).flatten() {
+        // parse message into a specific type
+        let user_notice = UserNotice::parse(&msg).unwrap();
+        // create an owned ('static) version of the message
+        let owned: UserNotice<'static> = user_notice.as_owned();
+        assert_eq!(user_notice, owned);
+
+        // or parse the message into a 'All' type
+        match AllCommands::parse(&msg).unwrap() {
+            AllCommands::UserNotice(notice) => {
+                // user_notice is a messages::UserNotice here
+                assert_eq!(user_notice, notice);
+            }
+            _ => {}
+        }
+
+        // the tags are parsed and are accessible as methods
+        // colors can be parsed into rgb/named types
+        assert_eq!(
+            user_notice.color().unwrap(),
+            "#59517B".parse::<twitchchat::color::Color>().unwrap()
+        );
+
+        // you can manually get tags from the message
+        let ts = user_notice.tags.get("tmi-sent-ts").unwrap();
+        assert_eq!(ts, "1580932171144");
+
+        // or as a type
+        let ts = user_notice
+            .tags
+            .get_parsed::<_, u64>("tmi-sent-ts")
+            .unwrap();
+        assert_eq!(ts, 1580932171144);
+    }
+
+    // parse one message at a time
+    // this returns the index of the start of the possible next message
+    let input =
+        ":tmi.twitch.tv PING 1234567\r\n:museun!museun@museun.tmi.twitch.tv JOIN #museun\r\n";
+
+    let (d, left) = twitchchat::decode_one(input).unwrap();
+    assert!(d > 0);
+    assert_eq!(left.command, "PING");
+
+    // use the new index
+    let (i, right) = twitchchat::decode_one(&input[d..]).unwrap();
+    assert_eq!(i, 0);
+    assert_eq!(right.command, "JOIN");
+}

--- a/examples/short.rs
+++ b/examples/short.rs
@@ -1,0 +1,41 @@
+use twitchchat::{events, Client, Secure};
+
+// so .next() can be used on the EventStream
+// futures::stream::StreamExt will also work
+use tokio::stream::StreamExt as _;
+
+#[tokio::main]
+async fn main() {
+    let (nick, pass) = twitchchat::ANONYMOUS_LOGIN;
+    let (read, write) = twitchchat::connect_easy(&nick, &pass, Secure::UseTls)
+        .await
+        .unwrap();
+
+    let client = Client::new();
+
+    // client is clonable and can be sent across tasks
+    let bot = client.clone();
+    tokio::task::spawn(async move {
+        // subscribe to 'PRIVMSG' events, this is a `Stream`
+        let mut privmsgs = bot.dispatcher().await.subscribe::<events::Privmsg>();
+        // 'msg' is a twitchchat::messages::Privmsg<'static> here
+        while let Some(msg) = privmsgs.next().await {
+            eprintln!("[{}] {}: {}", msg.channel, msg.name, msg.data);
+        }
+    });
+
+    // the writer is also clonable
+    client.writer().join("#museun").await.unwrap();
+
+    // this resolves when the client disconnects
+    // or is forced to stop with Client::stop
+    use twitchchat::client::Status;
+    match client.run(read, write).await {
+        // client was disconnected by the server
+        Ok(Status::Eof) => {}
+        // client was canceled by the user (`stop`)
+        Ok(Status::Canceled) => {}
+        // an error was received when trying to read or write
+        Err(err) => eprintln!("error!: {}", err),
+    };
+}

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -47,13 +47,13 @@ impl From<crate::ChannelError> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Utf8(err) => write!(f, "utf8 error: {}", err),
-            Error::Io(err) => write!(f, "io error: {}", err),
-            Error::Decode(err) => write!(f, "decode error: {}", err),
-            Error::NotRunning => write!(f, "tried to stop a non-running client"),
-            Error::AlreadyRunning => write!(f, "tried to start an already running client"),
-            Error::InvalidChannel(err) => write!(f, "an invalid channel was provided: {}", err),
-            Error::ClientDisconnect => write!(f, "this client has been disconnected"),
+            Self::Utf8(err) => write!(f, "utf8 error: {}", err),
+            Self::Io(err) => write!(f, "io error: {}", err),
+            Self::Decode(err) => write!(f, "decode error: {}", err),
+            Self::NotRunning => write!(f, "tried to stop a non-running client"),
+            Self::AlreadyRunning => write!(f, "tried to start an already running client"),
+            Self::InvalidChannel(err) => write!(f, "an invalid channel was provided: {}", err),
+            Self::ClientDisconnect => write!(f, "this client has been disconnected"),
         }
     }
 }
@@ -61,10 +61,10 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::Utf8(err) => Some(err),
-            Error::Io(err) => Some(err),
-            Error::Decode(err) => Some(err),
-            Error::InvalidChannel(err) => Some(err),
+            Self::Utf8(err) => Some(err),
+            Self::Io(err) => Some(err),
+            Self::Decode(err) => Some(err),
+            Self::InvalidChannel(err) => Some(err),
             _ => None,
         }
     }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -1,15 +1,54 @@
+use crate::AsOwned;
+use std::fmt::Debug;
+
 /// A marker trait for Event subscription
-pub trait Event<'a>: private::Sealed
-where
-    Self::Mapped: Clone + std::fmt::Debug,
-    Self::Mapped: Send + Sync + 'static,
-    Self::Mapped: crate::Parse<&'a crate::decode::Message<&'a str>>,
-{
-    /// Event message mapping
-    type Mapped;
+pub trait Event<'a>: crate::internal::private::event_marker::Sealed {
+    /// Event message parsing
+    type Parsed: crate::Parse<&'a crate::decode::Message<'a>> + AsOwned;
 }
 
-mod private {
-    pub trait Sealed {}
-    impl<'a, T> Sealed for T where T: super::Event<'a> {}
+/// A trait to convert an Event::Parsed to a 'static type
+pub trait EventMapped<'a, T>: crate::internal::private::mapped_marker::Sealed<T>
+where
+    T: Event<'a>,
+{
+    /// Event message mapping
+    type Owned: Clone + Debug + Send + Sync + 'static;
+    /// Converts this to the owned representation
+    fn into_owned(data: T::Parsed) -> Self::Owned;
+}
+
+impl<'a, T> EventMapped<'a, T> for T
+where
+    T: Event<'a>,
+    <T::Parsed as AsOwned>::Owned: Clone + Debug + Send + Sync + 'static,
+{
+    type Owned = <T::Parsed as AsOwned>::Owned;
+    fn into_owned(data: T::Parsed) -> Self::Owned {
+        <T::Parsed as AsOwned>::as_owned(&data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn event_mapped() {
+        fn e<'a, T>(msg: &'a crate::decode::Message<'a>) -> T::Owned
+        where
+            T: Event<'a> + 'static,
+            T: EventMapped<'a, T>,
+        {
+            use crate::Parse as _;
+            T::into_owned(T::Parsed::parse(msg).unwrap())
+        }
+
+        let msg = crate::decode("PING :1234567890\r\n")
+            .next()
+            .unwrap()
+            .unwrap();
+
+        let msg: crate::messages::Ping<'static> = e::<crate::events::Ping>(&msg);
+        assert_eq!(msg.token, "1234567890")
+    }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -28,6 +28,8 @@ use std::sync::Arc;
 use tokio::prelude::*;
 use tokio::sync::{mpsc, Mutex};
 
+use crate::rate_limit::*;
+
 mod dispatcher;
 pub use dispatcher::Dispatcher;
 
@@ -163,17 +165,20 @@ impl Client {
         Ok(())
     }
 
-    /// Run the client to completion, dispatching messages to the subscribers
+    /// This allow you provide a custom Rate Limit configuration
     ///
-    /// # Returns
-    /// * An [error][error] if one was encountered while in operation
-    /// * [`Ok(Status::Eof)`][eof] if it ran to completion
-    /// * [`Ok(Status::Canceled)`][cancel] if `stop` was called
+    /// See [Client::run](./struct.Client.html#method.run)
     ///
-    /// [error]: ./enum.Error.html
-    /// [eof]: ../client/enum.Status.html#variant.Eof
-    /// [cancel]: ../client/enum.Status.html#variant.Canceled
-    pub async fn run<R, W>(&self, read: R, write: W) -> Result<Status, Error>
+    /// # Warning
+    /// Having the wrong 'rate limit' will likely cause the server to drop you silently.
+    ///
+    /// Use this with caution, or if you know what you're doing
+    pub async fn run_with_user_rate_limit<R, W>(
+        &self,
+        read: R,
+        write: W,
+        rate: RateLimit,
+    ) -> Result<Status, Error>
     where
         R: AsyncRead + Send + Sync + Unpin + 'static,
         W: AsyncWrite + Send + Sync + Unpin + 'static,
@@ -193,7 +198,7 @@ impl Client {
             .expect("receiver to exist");
 
         let read = tokio::task::spawn(reader::read_loop(read, dispatcher));
-        let write = tokio::task::spawn(writer::write_loop(write, receiver));
+        let write = tokio::task::spawn(writer::write_loop(write, rate, receiver));
 
         let fut = futures::future::try_select(read, write);
         let (handle, token) = futures::future::AbortHandle::new_pair();
@@ -208,6 +213,29 @@ impl Client {
             Ok(Err(err)) => panic!("panic in read/write handler: {}", err.factor_first().0),
             Err(..) => Ok(Status::Canceled),
         }
+    }
+
+    /// Run the client to completion, dispatching messages to the subscribers
+    ///
+    /// # Note
+    /// This enables an internal rate limit of 50 messages sent per 30 seconds    
+    ///
+    /// # Returns
+    /// * An [error][error] if one was encountered while in operation
+    /// * [`Ok(Status::Eof)`][eof] if it ran to completion
+    /// * [`Ok(Status::Canceled)`][cancel] if `stop` was called
+    ///
+    /// [error]: ./enum.Error.html
+    /// [eof]: ../client/enum.Status.html#variant.Eof
+    /// [cancel]: ../client/enum.Status.html#variant.Canceled
+    // TODO allow for customization of the rate limiting
+    pub async fn run<R, W>(&self, read: R, write: W) -> Result<Status, Error>
+    where
+        R: AsyncRead + Send + Sync + Unpin + 'static,
+        W: AsyncWrite + Send + Sync + Unpin + 'static,
+    {
+        let rate = RateLimit::from_class(RateClass::Known);
+        self.run_with_user_rate_limit(read, write, rate).await
     }
 
     async fn initialize_handlers(&self) {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,6 @@
 /*!
+The client for reading/writing messages to Twitch
+
 # Event handling.
 
 You can [get] a [Dispatcher] from the [Client].
@@ -34,7 +36,7 @@ pub use stream::EventStream;
 
 mod event;
 #[doc(hidden)]
-pub use event::Event;
+pub use event::{Event, EventMapped};
 
 mod error;
 pub use error::Error;
@@ -95,9 +97,9 @@ tokio::task::spawn(async move {
 client.run(read_impl, write_impl).await;
 ```
 
-[Dispatcher]: ./struct.Dispatcher.html
-[Writer]: ./client/struct.Writer.html
-[Client]: ./struct.Client.html
+[Dispatcher]: ../client/struct.Dispatcher.html
+[Writer]: ../client/struct.Writer.html
+[Client]: ../client/struct.Client.html
 [AsyncRead]: https://docs.rs/tokio/0.2.6/tokio/io/trait.AsyncRead.html
 [AsyncWrite]: https://docs.rs/tokio/0.2.6/tokio/io/trait.AsyncWrite.html
 [Stream]: https://docs.rs/futures/0.3.1/futures/stream/trait.Stream.html
@@ -169,8 +171,8 @@ impl Client {
     /// * [`Ok(Status::Canceled)`][cancel] if `stop` was called
     ///
     /// [error]: ./enum.Error.html
-    /// [eof]: ./client/enum.Status.html#variant.Eof
-    /// [cancel]: ./client/enum.Status.html#variant.Canceled
+    /// [eof]: ../client/enum.Status.html#variant.Eof
+    /// [cancel]: ../client/enum.Status.html#variant.Canceled
     pub async fn run<R, W>(&self, read: R, write: W) -> Result<Status, Error>
     where
         R: AsyncRead + Send + Sync + Unpin + 'static,

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -28,7 +28,7 @@ trait SafeEncode {
         F: FnMut(&mut Self) -> std::io::Result<()>,
     {
         match func(self) {
-            Ok(res) => Ok(res),
+            Ok(_) => Ok(()),
             Err(err) => {
                 self.clear_data();
                 Err(err)

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -4,6 +4,7 @@ use crate::IntoChannel;
 
 pub(super) async fn write_loop<W>(
     write: W,
+    mut rate: RateLimit,
     mut recv: Receiver,
 ) -> std::result::Result<Status, Error>
 where
@@ -11,6 +12,7 @@ where
 {
     let mut writer = tokio::io::BufWriter::new(write);
     while let Some(data) = recv.next().await {
+        let _ = rate.take().await;
         log::trace!("> {}", std::str::from_utf8(&data).unwrap().escape_debug());
         writer.write_all(&data).await?;
         writer.flush().await?

--- a/src/decode/error.rs
+++ b/src/decode/error.rs
@@ -18,11 +18,11 @@ pub enum ParseError {
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParseError::EmptyLine => f.write_str("an empty line was attempted to be decoded"),
-            ParseError::IncompleteMessage { pos } => {
+            Self::EmptyLine => f.write_str("an empty line was attempted to be decoded"),
+            Self::IncompleteMessage { pos } => {
                 write!(f, "an incomplete message was parsed. at {}", pos)
             }
-            ParseError::EmptyMessage => f.write_str("an empty message was parsed"),
+            Self::EmptyMessage => f.write_str("an empty message was parsed"),
         }
     }
 }

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -9,16 +9,18 @@ type Result<T> = std::result::Result<T, ParseError>;
 ## A single message
 ```rust
 # use twitchchat::*;
+# use std::borrow::Cow;
+
 let input = ":test!test@test JOIN #museun\r\n";
 let (pos, message) = decode_one(&input).unwrap();
 assert_eq!(pos, 0); // no more messages were found
 
 let expected = messages::Raw {
-    raw: ":test!test@test JOIN #museun\r\n",
+    raw: Cow::Borrowed(":test!test@test JOIN #museun\r\n"),
     tags: Tags::default(),
-    prefix: Some(decode::Prefix::User { nick: "test" }),
-    command: "JOIN",
-    args: "#museun",
+    prefix: Some(decode::Prefix::User { nick: Cow::Borrowed("test") }),
+    command: Cow::Borrowed("JOIN"),
+    args: Cow::Borrowed("#museun"),
     data: None,
 };
 assert_eq!(message, expected);
@@ -27,16 +29,18 @@ assert_eq!(message, expected);
 # Multiple messages
 ```rust
 # use twitchchat::*;
+# use std::borrow::Cow;
+
 let input = ":test!test@test JOIN #museun\r\n:test!test@test JOIN #shaken_bot\r\n";
 let (pos, message) = decode_one(&input).unwrap();
 assert_eq!(pos, 30); // another message probably starts at offset '30'
 
 let expected = messages::Raw {
-    raw: ":test!test@test JOIN #museun\r\n",
+    raw: Cow::Borrowed(":test!test@test JOIN #museun\r\n"),
     tags: Tags::default(),
-    prefix: Some(decode::Prefix::User { nick: "test" }),
-    command: "JOIN",
-    args: "#museun",
+    prefix: Some(decode::Prefix::User { nick: Cow::Borrowed("test") }),
+    command: Cow::Borrowed("JOIN"),
+    args: Cow::Borrowed("#museun"),
     data: None,
 };
 assert_eq!(message, expected);
@@ -46,17 +50,17 @@ let (pos, message) = decode_one(&input[pos..]).unwrap();
 assert_eq!(pos, 0); // no more messages were found
 
 let expected = messages::Raw {
-    raw: ":test!test@test JOIN #shaken_bot\r\n",
+    raw: Cow::Borrowed(":test!test@test JOIN #shaken_bot\r\n"),
     tags: Tags::default(),
-    prefix: Some(decode::Prefix::User { nick: "test" }),
-    command: "JOIN",
-    args: "#shaken_bot",
+    prefix: Some(decode::Prefix::User { nick: Cow::Borrowed("test") }),
+    command: Cow::Borrowed("JOIN"),
+    args: Cow::Borrowed("#shaken_bot"),
     data: None,
 };
 assert_eq!(message, expected);
 ```
 */
-pub fn decode_one(input: &str) -> Result<(usize, Message<&'_ str>)> {
+pub fn decode_one<'t>(input: &'t str) -> Result<(usize, Message<'t>)> {
     let pos = input
         .find("\r\n")
         .ok_or_else(|| ParseError::IncompleteMessage { pos: 0 })?;
@@ -70,23 +74,25 @@ Tries to decode potentially many messages from this input string
 # Example
 ```rust
 # use twitchchat::*;
+# use std::borrow::Cow;
+
 let input = ":test!test@test JOIN #museun\r\n:test!test@test JOIN #shaken_bot\r\n";
 
 let expected = &[
     messages::Raw {
-        raw: ":test!test@test JOIN #museun\r\n",
+        raw: Cow::Borrowed(":test!test@test JOIN #museun\r\n"),
         tags: Tags::default(),
-        prefix: Some(decode::Prefix::User { nick: "test" }),
-        command: "JOIN",
-        args: "#museun",
+        prefix: Some(decode::Prefix::User { nick: Cow::Borrowed("test") }),
+        command: Cow::Borrowed("JOIN"),
+        args: Cow::Borrowed("#museun"),
         data: None,
     },
     messages::Raw {
-        raw: ":test!test@test JOIN #shaken_bot\r\n",
+        raw: Cow::Borrowed(":test!test@test JOIN #shaken_bot\r\n"),
         tags: Tags::default(),
-        prefix: Some(decode::Prefix::User { nick: "test" }),
-        command: "JOIN",
-        args: "#shaken_bot",
+        prefix: Some(decode::Prefix::User { nick: Cow::Borrowed("test") }),
+        command: Cow::Borrowed("JOIN"),
+        args: Cow::Borrowed("#shaken_bot"),
         data: None,
     },
 ];
@@ -97,7 +103,7 @@ for (message, expected) in decode(&input).zip(expected.iter()) {
 }
 ```
 */
-pub fn decode(input: &str) -> impl Iterator<Item = Result<Message<&'_ str>>> + '_ {
+pub fn decode<'t>(input: &'t str) -> impl Iterator<Item = Result<Message<'t>>> + 't {
     ParseIter::new(input)
 }
 

--- a/src/decode/parser.rs
+++ b/src/decode/parser.rs
@@ -7,12 +7,12 @@ pub(super) struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    pub(super) fn new(input: &'a str) -> Self {
+    pub(super) const fn new(input: &'a str) -> Self {
         Self { input, pos: 0 }
     }
 
     // '@tags '
-    pub(super) fn tags(&mut self) -> Tags<&'a str> {
+    pub(super) fn tags(&mut self) -> Tags<'a> {
         let input = &self.input[self.pos..];
         if input.starts_with('@') {
             if let Some(pos) = input.find(' ') {
@@ -24,7 +24,7 @@ impl<'a> Parser<'a> {
     }
 
     // ':prefix '
-    pub(super) fn prefix(&mut self) -> Option<Prefix<&'a str>> {
+    pub(super) fn prefix(&mut self) -> Option<Prefix<'a>> {
         let input = &self.input[self.pos..];
         if !input.starts_with("tmi.twitch.tv") && !input.starts_with(':') {
             return None;
@@ -51,7 +51,7 @@ impl<'a> Parser<'a> {
         let input = &self.input[self.pos..];
         let pos = input.find(':').unwrap_or_else(|| input.len());
         self.pos += pos + 1;
-        &input[..pos].trim()
+        input[..pos].trim()
     }
 
     // ':data'
@@ -66,13 +66,13 @@ pub(super) struct ParseIter<'a> {
 }
 
 impl<'a> ParseIter<'a> {
-    pub(super) fn new(input: &'a str) -> Self {
+    pub(super) const fn new(input: &'a str) -> Self {
         Self { input, pos: 0 }
     }
 }
 
 impl<'a> Iterator for ParseIter<'a> {
-    type Item = Result<Message<&'a str>>;
+    type Item = Result<Message<'a>>;
     fn next(&mut self) -> Option<Self::Item> {
         const CRLF: &str = "\r\n";
         if self.pos == self.input.len() {

--- a/src/decode/prefix.rs
+++ b/src/decode/prefix.rs
@@ -1,51 +1,45 @@
+use std::borrow::Cow;
+
 /// Prefix is the sender of a message
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Prefix<T>
-where
-    T: crate::StringMarker,
-{
+pub enum Prefix<'t> {
     /// A user sent this message
     User {
         /// Name of the user
-        nick: T,
+        nick: Cow<'t, str>,
     },
     /// The server sent this message
     Server {
         /// Name of the server
-        host: T,
+        host: Cow<'t, str>,
     },
 }
 
-impl<'a> Prefix<&'a str> {
-    pub(super) fn parse(input: &'a str) -> Option<Self> {
-        let offset = if input.starts_with(':') {
-            1
-        } else if input == "tmi.twitch.tv" {
-            0
-        } else {
-            return None;
+impl<'t> Prefix<'t> {
+    pub(super) fn parse(input: &'t str) -> Option<Self> {
+        let offset = match input {
+            s if s.starts_with(':') => 1,
+            "tmi.twitch.tv" => 0,
+            _ => return None,
         };
 
         let input = input[offset..input.find(' ').unwrap_or_else(|| input.len())].trim();
         let prefix = match input.find('!') {
             Some(pos) => Prefix::User {
-                nick: &input[..pos],
+                nick: input[..pos].into(),
             },
-            None => Prefix::Server { host: input },
+            None => Prefix::Server { host: input.into() },
         };
         prefix.into()
     }
 }
 
-impl<T> Prefix<T>
-where
-    T: crate::StringMarker,
-{
+impl<'t> Prefix<'t> {
     /// The user name in this prefix
     ///
     /// This is the name of the user if a user had sent the message
-    pub fn nick(&self) -> Option<&T> {
+    pub fn nick(&'t self) -> Option<&Cow<'t, str>> {
         match self {
             Prefix::User { nick } => Some(nick),
             _ => None,
@@ -55,7 +49,7 @@ where
     /// The host name in this prefix
     ///
     /// This is the name of the server if the server had sent the message
-    pub fn host(&self) -> Option<&T> {
+    pub fn host(&'t self) -> Option<&Cow<'t, str>> {
         match self {
             Prefix::Server { host } => Some(host),
             _ => None,

--- a/src/decode/tests.rs
+++ b/src/decode/tests.rs
@@ -89,7 +89,7 @@ fn cap_ack() {
     assert_eq!(
         msg.prefix.unwrap(),
         Prefix::Server {
-            host: "tmi.twitch.tv"
+            host: "tmi.twitch.tv".into()
         }
     );
     assert_eq!(msg.command, "CAP");

--- a/src/encode/encoder.rs
+++ b/src/encode/encoder.rs
@@ -24,7 +24,7 @@ impl<W> std::fmt::Debug for Encoder<W> {
 
 impl<W: Write + Clone> Clone for Encoder<W> {
     fn clone(&self) -> Self {
-        Encoder {
+        Self {
             writer: self.writer.clone(),
         }
     }
@@ -325,7 +325,7 @@ where
     /// Use [vips] to list the VIPs of this channel.
     ///
     /// [vips]: ./struct.Encoder.html#methodruct.html#method.vips
-    pub  fn unvip(&mut self, username: &str) -> Result {
+    pub fn unvip(&mut self, username: &str) -> Result {
         self.command(&format!("/unvip {}", username))
     }
 
@@ -334,7 +334,7 @@ where
     /// Use [vips] to list the VIPs of this channel.
     ///
     /// [vips]: ./struct.Encoder.html#methodruct.html#method.vips
-    pub  fn vip(&mut self, username: &str) -> Result {
+    pub fn vip(&mut self, username: &str) -> Result {
         self.command(&format!("/vip {}", username))
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -11,27 +11,206 @@ See the [table]
 [table]: ../client/struct.Dispatcher.html#a-table-of-mappings
 */
 use super::*;
+use crate::client::Event;
 
-make_event! {
-    Cap             => messages::Cap
-    ClearChat       => messages::ClearChat
-    ClearMsg        => messages::ClearMsg
-    GlobalUserState => messages::GlobalUserState
-    HostTarget      => messages::HostTarget
-    IrcReady        => messages::IrcReady
-    Join            => messages::Join
-    Mode            => messages::Mode
-    Names           => messages::Names
-    Notice          => messages::Notice
-    Part            => messages::Part
-    Ping            => messages::Ping
-    Pong            => messages::Pong
-    Privmsg         => messages::Privmsg
-    Raw             => messages::Raw<String>
-    Ready           => messages::Ready
-    Reconnect       => messages::Reconnect
-    RoomState       => messages::RoomState
-    UserState       => messages::UserState
+/// Used to get a [messages::Cap][Cap]
+///
+/// [Cap]: ../messages/struct.Cap.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Cap;
+impl<'t> Event<'t> for Cap {
+    type Parsed = messages::Cap<'t>;
+}
+
+/// Used to get a [messages::ClearChat][ClearChat]
+///
+/// [ClearChat]: ../messages/struct.ClearChat.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct ClearChat;
+impl<'t> Event<'t> for ClearChat {
+    type Parsed = messages::ClearChat<'t>;
+}
+
+/// Used to get a [messages::ClearMsg][ClearMsg]
+///
+/// [ClearMsg]: ../messages/struct.ClearMsg.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct ClearMsg;
+impl<'t> Event<'t> for ClearMsg {
+    type Parsed = messages::ClearMsg<'t>;
+}
+
+/// Used to get a [messages::GlobalUserState][GlobalUserState]
+///
+/// [GlobalUserState]: ../messages/struct.GlobalUserState.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct GlobalUserState;
+impl<'t> Event<'t> for GlobalUserState {
+    type Parsed = messages::GlobalUserState<'t>;
+}
+
+/// Used to get a [messages::HostTarget][HostTarget]
+///
+/// [HostTarget]: ../messages/struct.HostTarget.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct HostTarget;
+impl<'t> Event<'t> for HostTarget {
+    type Parsed = messages::HostTarget<'t>;
+}
+
+/// Used to get a [messages::IrcReady][IrcReady]
+///
+/// [IrcReady]: ../messages/struct.IrcReady.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct IrcReady;
+impl<'t> Event<'t> for IrcReady {
+    type Parsed = messages::IrcReady<'t>;
+}
+
+/// Used to get a [messages::Join][Join]
+///
+/// [Join]: ../messages/struct.Join.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Join;
+impl<'t> Event<'t> for Join {
+    type Parsed = messages::Join<'t>;
+}
+
+/// Used to get a [messages::Mode][Mode]
+///
+/// [Mode]: ../messages/struct.Mode.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Mode;
+impl<'t> Event<'t> for Mode {
+    type Parsed = messages::Mode<'t>;
+}
+
+/// Used to get a [messages::Names][Names]
+///
+/// [Names]: ../messages/struct.Names.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Names;
+impl<'t> Event<'t> for Names {
+    type Parsed = messages::Names<'t>;
+}
+
+/// Used to get a [messages::Notice][Notice]
+///
+/// [Notice]: ../messages/struct.Notice.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Notice;
+impl<'t> Event<'t> for Notice {
+    type Parsed = messages::Notice<'t>;
+}
+
+/// Used to get a [messages::Part][Part]
+///
+/// [Part]: ../messages/struct.Part.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Part;
+impl<'t> Event<'t> for Part {
+    type Parsed = messages::Part<'t>;
+}
+
+/// Used to get a [messages::Ping][Ping]
+///
+/// [Ping]: ../messages/struct.Ping.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Ping;
+impl<'t> Event<'t> for Ping {
+    type Parsed = messages::Ping<'t>;
+}
+
+/// Used to get a [messages::Pong][Pong]
+///
+/// [Pong]: ../messages/struct.Pong.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Pong;
+impl<'t> Event<'t> for Pong {
+    type Parsed = messages::Pong<'t>;
+}
+
+/// Used to get a [messages::Privmsg][Privmsg]
+///
+/// [Privmsg]: ../messages/struct.Privmsg.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Privmsg;
+impl<'t> Event<'t> for Privmsg {
+    type Parsed = messages::Privmsg<'t>;
+}
+
+/// Used to get a [messages::Raw][Raw]
+///
+/// [Raw]: ../messages/type.Raw.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Raw;
+impl<'t> Event<'t> for Raw {
+    type Parsed = messages::Raw<'t>;
+}
+
+/// Used to get a [messages::Ready][Ready]
+///
+/// [Ready]: ../messages/struct.Ready.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Ready;
+impl<'t> Event<'t> for Ready {
+    type Parsed = messages::Ready<'t>;
+}
+
+/// Used to get a [messages::Reconnect][Reconnect]
+///
+/// [Reconnect]: ../messages/struct.Reconnect.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Reconnect;
+impl<'t> Event<'t> for Reconnect {
+    type Parsed = messages::Reconnect;
+}
+
+/// Used to get a [messages::RoomState][RoomState]
+///
+/// [RoomState]: ../messages/struct.RoomState.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct RoomState;
+impl<'t> Event<'t> for RoomState {
+    type Parsed = messages::RoomState<'t>;
+}
+
+/// Used to get a [messages::UserNotice][UserNotice]
+///
+/// [UserNotice]: ../messages/struct.UserNotice.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct UserNotice;
+impl<'t> Event<'t> for UserNotice {
+    type Parsed = messages::UserNotice<'t>;
+}
+
+/// Used to get a [messages::UserState][UserState]
+///
+/// [UserState]: ../messages/struct.UserState.html
+#[non_exhaustive]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct UserState;
+impl<'t> Event<'t> for UserState {
+    type Parsed = messages::UserState<'t>;
 }
 
 /// Used to get a [messages::AllCommands][AllCommands]
@@ -40,7 +219,6 @@ make_event! {
 #[non_exhaustive]
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct All;
-
-impl<'a> crate::client::Event<'a> for All {
-    type Mapped = messages::AllCommands;
+impl<'t> Event<'t> for All {
+    type Parsed = messages::AllCommands<'t>;
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,671 +1,157 @@
-use crate::Conversion;
-use std::{borrow::Borrow, fmt::Debug, hash::Hash};
+use crate::color::Color;
+use crate::messages::*;
+use crate::AsOwned;
+use crate::{Badge, BadgeKind};
+use std::borrow::Cow;
 
-/// Marker trait for the 'storage' abstraction of the types
-pub trait StringMarker
-where
-    Self: Hash + Debug + Clone,
-    Self: Eq + PartialEq + AsRef<str> + Borrow<str>,
-    Self: private::string_marker::Sealed,
-{
+pub(crate) mod private {
+    pub(crate) mod parse_marker {
+        pub trait Sealed<E> {}
+        impl<T, E> Sealed<E> for T
+        where
+            T: crate::Parse<E>,
+            E: Sized,
+        {
+        }
+    }
+
+    pub(crate) mod asowned_marker {
+        pub trait Sealed {}
+        impl<T> Sealed for T where T: crate::AsOwned {}
+    }
+
+    pub(crate) mod event_marker {
+        pub trait Sealed {}
+        impl<'a, T> Sealed for T where T: crate::client::Event<'a> {}
+    }
+
+    pub(crate) mod mapped_marker {
+        pub trait Sealed<E> {}
+        impl<'a, T, E> Sealed<E> for T
+        where
+            T: crate::client::EventMapped<'a, E>,
+            E: crate::client::Event<'a>,
+        {
+        }
+    }
 }
 
-impl StringMarker for String {}
-impl<'a> StringMarker for &'a str {}
-
-impl<'a> Conversion<'a> for bool {
-    type Borrowed = bool;
-    type Owned = bool;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        *self
-    }
+impl AsOwned for bool {
+    type Owned = Self;
     fn as_owned(&self) -> Self::Owned {
         *self
     }
 }
 
-impl<'a> Conversion<'a> for usize {
-    type Borrowed = usize;
-    type Owned = usize;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        *self
-    }
+impl AsOwned for usize {
+    type Owned = Self;
     fn as_owned(&self) -> Self::Owned {
         *self
     }
 }
 
-impl<'a> Conversion<'a> for &'a str {
-    type Borrowed = &'a str;
-    type Owned = String;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        self
-    }
-    fn as_owned(&self) -> Self::Owned {
-        self.to_string()
-    }
-}
-
-impl<'a> Conversion<'a> for String {
-    type Borrowed = &'a str;
-    type Owned = String;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        self.as_str()
-    }
-    fn as_owned(&self) -> Self::Owned {
-        self.clone()
+impl<'a> AsOwned for Cow<'a, str> {
+    type Owned = Cow<'static, str>;
+    fn as_owned(&self) -> <Self as AsOwned>::Owned {
+        match self {
+            Cow::Borrowed(r) => Cow::Owned(r.to_owned().into()),
+            Cow::Owned(s) => Cow::Owned(s.clone()),
+        }
     }
 }
 
-impl<'a, T> Conversion<'a> for Option<T>
-where
-    T: Conversion<'a>,
-{
-    type Borrowed = Option<T::Borrowed>;
+impl<T: AsOwned + Clone> AsOwned for Option<T> {
     type Owned = Option<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        self.as_ref().map(|s| s.as_borrowed())
+    fn as_owned(&self) -> Self::Owned {
+        self.clone().map(|s| s.as_owned())
     }
+}
+
+impl<T: AsOwned + Clone> AsOwned for Vec<T> {
+    type Owned = Vec<T::Owned>;
+    fn as_owned(&self) -> Self::Owned {
+        self.iter().cloned().map(|s| s.as_owned()).collect()
+    }
+}
+
+impl<'t> AsOwned for ModeStatus {
+    type Owned = Self;
+    fn as_owned(&self) -> Self::Owned {
+        *self
+    }
+}
+
+impl AsOwned for Color {
+    type Owned = Self;
+    fn as_owned(&self) -> Self::Owned {
+        *self
+    }
+}
+
+impl<'t> AsOwned for HostTargetKind<'t> {
+    type Owned = HostTargetKind<'static>;
     fn as_owned(&self) -> Self::Owned {
         match self {
-            Some(item) => Some(item.as_owned()),
-            None => None,
+            HostTargetKind::Start { target } => HostTargetKind::Start {
+                target: target.as_owned(),
+            },
+            HostTargetKind::End => HostTargetKind::End,
         }
     }
 }
 
-impl<'a, T> Conversion<'a> for Vec<T>
-where
-    T: Conversion<'a>,
-{
-    type Borrowed = Vec<T::Borrowed>;
-    type Owned = Vec<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        self.iter().map(|s| s.as_borrowed()).collect()
-    }
+impl<'t> AsOwned for NamesKind<'t> {
+    type Owned = NamesKind<'static>;
     fn as_owned(&self) -> Self::Owned {
-        self.iter().map(|s| s.as_owned()).collect()
+        match self {
+            NamesKind::Start { users } => NamesKind::Start {
+                users: users.as_owned(),
+            },
+            NamesKind::End => NamesKind::End,
+        }
     }
 }
 
-impl<'a, T> Conversion<'a> for crate::Badge<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::Badge<T::Borrowed>;
-    type Owned = crate::Badge<T::Owned>;
-
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        crate::Badge {
-            kind: self.kind.as_borrowed(),
-            data: self.data.as_borrowed(),
+impl<'t> AsOwned for BadgeKind<'t> {
+    type Owned = BadgeKind<'static>;
+    fn as_owned(&self) -> Self::Owned {
+        match self {
+            BadgeKind::Admin => BadgeKind::Admin,
+            BadgeKind::Bits => BadgeKind::Bits,
+            BadgeKind::Broadcaster => BadgeKind::Broadcaster,
+            BadgeKind::GlobalMod => BadgeKind::GlobalMod,
+            BadgeKind::Moderator => BadgeKind::Moderator,
+            BadgeKind::Subscriber => BadgeKind::Subscriber,
+            BadgeKind::Staff => BadgeKind::Staff,
+            BadgeKind::Turbo => BadgeKind::Turbo,
+            BadgeKind::Premium => BadgeKind::Premium,
+            BadgeKind::VIP => BadgeKind::VIP,
+            BadgeKind::Partner => BadgeKind::Partner,
+            BadgeKind::Unknown(s) => BadgeKind::Unknown(s.as_owned()),
         }
     }
+}
+
+impl<'t> AsOwned for Badge<'t> {
+    type Owned = Badge<'static>;
     fn as_owned(&self) -> Self::Owned {
-        crate::Badge {
+        Badge {
             kind: self.kind.as_owned(),
             data: self.data.as_owned(),
         }
     }
 }
 
-impl<'a, T> Conversion<'a> for crate::BadgeKind<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::BadgeKind<T::Borrowed>;
-    type Owned = crate::BadgeKind<T::Owned>;
-
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        use crate::BadgeKind::*;
-        match self {
-            Admin => Admin,
-            Bits => Bits,
-            Broadcaster => Broadcaster,
-            GlobalMod => GlobalMod,
-            Moderator => Moderator,
-            Subscriber => Subscriber,
-            Staff => Staff,
-            Turbo => Turbo,
-            Premium => Premium,
-            VIP => VIP,
-            Partner => Partner,
-            Unknown(inner) => Unknown(inner.as_borrowed()),
-        }
-    }
+impl<'a> AsOwned for crate::Tags<'a> {
+    type Owned = crate::Tags<'static>;
     fn as_owned(&self) -> Self::Owned {
-        use crate::BadgeKind::*;
-        match self {
-            Admin => Admin,
-            Bits => Bits,
-            Broadcaster => Broadcaster,
-            GlobalMod => GlobalMod,
-            Moderator => Moderator,
-            Subscriber => Subscriber,
-            Staff => Staff,
-            Turbo => Turbo,
-            Premium => Premium,
-            VIP => VIP,
-            Partner => Partner,
-            Unknown(inner) => Unknown(inner.as_owned()),
-        }
+        let map = self.0.iter().map(|(k, v)| (k.as_owned(), v.as_owned()));
+        crate::Tags(map.collect())
     }
 }
 
-impl<'a> Conversion<'a> for crate::color::Color {
-    type Borrowed = crate::color::Color;
-    type Owned = crate::color::Color;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        *self
-    }
-    fn as_owned(&self) -> Self::Owned {
-        *self
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::Tags<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::Tags<T::Borrowed>;
-    type Owned = crate::Tags<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        crate::Tags(
-            self.0
-                .iter()
-                .map(|(k, v)| (k.as_borrowed(), v.as_borrowed()))
-                .collect(),
-        )
-    }
-    fn as_owned(&self) -> Self::Owned {
-        crate::Tags(
-            self.0
-                .iter()
-                .map(|(k, v)| (k.as_owned(), v.as_owned()))
-                .collect(),
-        )
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::messages::NamesKind<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::messages::NamesKind<T::Borrowed>;
-    type Owned = crate::messages::NamesKind<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        match self {
-            crate::messages::NamesKind::Start { users } => crate::messages::NamesKind::Start {
-                users: users.as_borrowed(),
-            },
-            crate::messages::NamesKind::End => crate::messages::NamesKind::End,
-        }
-    }
-    fn as_owned(&self) -> Self::Owned {
-        match self {
-            crate::messages::NamesKind::Start { users } => crate::messages::NamesKind::Start {
-                users: users.as_owned(),
-            },
-            crate::messages::NamesKind::End => crate::messages::NamesKind::End,
-        }
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::messages::HostTargetKind<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::messages::HostTargetKind<T::Borrowed>;
-    type Owned = crate::messages::HostTargetKind<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        match self {
-            crate::messages::HostTargetKind::Start { target } => {
-                crate::messages::HostTargetKind::Start {
-                    target: target.as_borrowed(),
-                }
-            }
-            crate::messages::HostTargetKind::End => crate::messages::HostTargetKind::End,
-        }
-    }
-    fn as_owned(&self) -> Self::Owned {
-        match self {
-            crate::messages::HostTargetKind::Start { target } => {
-                crate::messages::HostTargetKind::Start {
-                    target: target.as_owned(),
-                }
-            }
-            crate::messages::HostTargetKind::End => crate::messages::HostTargetKind::End,
-        }
-    }
-}
-
-impl<'a> Conversion<'a> for crate::messages::ModeStatus {
-    type Borrowed = crate::messages::ModeStatus;
-    type Owned = crate::messages::ModeStatus;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        *self
-    }
-    fn as_owned(&self) -> Self::Owned {
-        *self
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::messages::NoticeType<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::messages::NoticeType<T::Borrowed>;
-    type Owned = crate::messages::NoticeType<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        use crate::messages::NoticeType::*;
-        match self {
-            Sub => Sub,
-            Resub => Resub,
-            SubGift => SubGift,
-            AnonSubGift => AnonSubGift,
-            SubMysteryGift => SubMysteryGift,
-            GiftPaidUpgrade => GiftPaidUpgrade,
-            RewardGift => RewardGift,
-            AnonGiftPaidUpgrade => AnonGiftPaidUpgrade,
-            Raid => Raid,
-            Unraid => Unraid,
-            Ritual => Ritual,
-            BitsBadgeTier => BitsBadgeTier,
-            Unknown(data) => Unknown(data.as_borrowed()),
-        }
-    }
-    fn as_owned(&self) -> Self::Owned {
-        use crate::messages::NoticeType::*;
-        match self {
-            Sub => Sub,
-            Resub => Resub,
-            SubGift => SubGift,
-            AnonSubGift => AnonSubGift,
-            SubMysteryGift => SubMysteryGift,
-            GiftPaidUpgrade => GiftPaidUpgrade,
-            RewardGift => RewardGift,
-            AnonGiftPaidUpgrade => AnonGiftPaidUpgrade,
-            Raid => Raid,
-            Unraid => Unraid,
-            Ritual => Ritual,
-            BitsBadgeTier => BitsBadgeTier,
-            Unknown(data) => Unknown(data.as_owned()),
-        }
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::messages::MessageId<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::messages::MessageId<T::Borrowed>;
-    type Owned = crate::messages::MessageId<T::Owned>;
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        use crate::messages::MessageId::*;
-        match self {
-            AlreadyBanned => AlreadyBanned,
-            AlreadyEmoteOnlyOff => AlreadyEmoteOnlyOff,
-            AlreadyEmoteOnlyOn => AlreadyEmoteOnlyOn,
-            AlreadyR9kOff => AlreadyR9kOff,
-            AlreadyR9kOn => AlreadyR9kOn,
-            AlreadySubsOff => AlreadySubsOff,
-            AlreadySubsOn => AlreadySubsOn,
-            BadBanAdmin => BadBanAdmin,
-            BadBanAnon => BadBanAnon,
-            BadBanBroadcaster => BadBanBroadcaster,
-            BadBanGlobalMod => BadBanGlobalMod,
-            BadBanMod => BadBanMod,
-            BadBanSelf => BadBanSelf,
-            BadBanStaff => BadBanStaff,
-            BadCommercialError => BadCommercialError,
-            BadDeleteMessageBroadcaster => BadDeleteMessageBroadcaster,
-            BadDeleteMessageMod => BadDeleteMessageMod,
-            BadHostError => BadHostError,
-            BadHostHosting => BadHostHosting,
-            BadHostRateExceeded => BadHostRateExceeded,
-            BadHostRejected => BadHostRejected,
-            BadHostSelf => BadHostSelf,
-            BadMarkerClient => BadMarkerClient,
-            BadModBanned => BadModBanned,
-            BadModMod => BadModMod,
-            BadSlowDuration => BadSlowDuration,
-            BadTimeoutAdmin => BadTimeoutAdmin,
-            BadTimeoutAnon => BadTimeoutAnon,
-            BadTimeoutBroadcaster => BadTimeoutBroadcaster,
-            BadTimeoutDuration => BadTimeoutDuration,
-            BadTimeoutGlobalMod => BadTimeoutGlobalMod,
-            BadTimeoutMod => BadTimeoutMod,
-            BadTimeoutSelf => BadTimeoutSelf,
-            BadTimeoutStaff => BadTimeoutStaff,
-            BadUnbanNoBan => BadUnbanNoBan,
-            BadUnhostError => BadUnhostError,
-            BadUnmodMod => BadUnmodMod,
-            BanSuccess => BanSuccess,
-            CmdsAvailable => CmdsAvailable,
-            ColorChanged => ColorChanged,
-            CommercialSuccess => CommercialSuccess,
-            DeleteMessageSuccess => DeleteMessageSuccess,
-            EmoteOnlyOff => EmoteOnlyOff,
-            EmoteOnlyOn => EmoteOnlyOn,
-            FollowersOff => FollowersOff,
-            FollowersOn => FollowersOn,
-            FollowersOnZero => FollowersOnZero,
-            HostOff => HostOff,
-            HostOn => HostOn,
-            HostSuccess => HostSuccess,
-            HostSuccessViewers => HostSuccessViewers,
-            HostTargetWentOffline => HostTargetWentOffline,
-            HostsRemaining => HostsRemaining,
-            InvalidUser => InvalidUser,
-            ModSuccess => ModSuccess,
-            MsgBanned => MsgBanned,
-            MsgBadCharacters => MsgBadCharacters,
-            MsgChannelBlocked => MsgChannelBlocked,
-            MsgChannelSuspended => MsgChannelSuspended,
-            MsgDuplicate => MsgDuplicate,
-            MsgEmoteonly => MsgEmoteonly,
-            MsgFacebook => MsgFacebook,
-            MsgFollowersonly => MsgFollowersonly,
-            MsgFollowersonlyFollowed => MsgFollowersonlyFollowed,
-            MsgFollowersonlyZero => MsgFollowersonlyZero,
-            MsgR9k => MsgR9k,
-            MsgRatelimit => MsgRatelimit,
-            MsgRejected => MsgRejected,
-            MsgRejectedMandatory => MsgRejectedMandatory,
-            MsgRoomNotFound => MsgRoomNotFound,
-            MsgSlowmode => MsgSlowmode,
-            MsgSubsonly => MsgSubsonly,
-            MsgSuspended => MsgSuspended,
-            MsgTimedout => MsgTimedout,
-            MsgVerifiedEmail => MsgVerifiedEmail,
-            NoHelp => NoHelp,
-            NoMods => NoMods,
-            NotHosting => NotHosting,
-            NoPermission => NoPermission,
-            R9kOff => R9kOff,
-            R9kOn => R9kOn,
-            RaidErrorAlreadyRaiding => RaidErrorAlreadyRaiding,
-            RaidErrorForbidden => RaidErrorForbidden,
-            RaidErrorSelf => RaidErrorSelf,
-            RaidErrorTooManyViewers => RaidErrorTooManyViewers,
-            RaidErrorUnexpected => RaidErrorUnexpected,
-            RaidNoticeMature => RaidNoticeMature,
-            RaidNoticeRestrictedChat => RaidNoticeRestrictedChat,
-            RoomMods => RoomMods,
-            SlowOff => SlowOff,
-            SlowOn => SlowOn,
-            SubsOff => SubsOff,
-            SubsOn => SubsOn,
-            TimeoutNoTimeout => TimeoutNoTimeout,
-            TimeoutSuccess => TimeoutSuccess,
-            TosBan => TosBan,
-            TurboOnlyColor => TurboOnlyColor,
-            UnbanSuccess => UnbanSuccess,
-            UnmodSuccess => UnmodSuccess,
-            UnraidErrorNoActiveRaid => UnraidErrorNoActiveRaid,
-            UnraidErrorUnexpected => UnraidErrorUnexpected,
-            UnraidSuccess => UnraidSuccess,
-            UnrecognizedCmd => UnrecognizedCmd,
-            UnsupportedChatroomsCmd => UnsupportedChatroomsCmd,
-            UntimeoutBanned => UntimeoutBanned,
-            UntimeoutSuccess => UntimeoutSuccess,
-            UsageBan => UsageBan,
-            UsageClear => UsageClear,
-            UsageColor => UsageColor,
-            UsageCommercial => UsageCommercial,
-            UsageDisconnect => UsageDisconnect,
-            UsageEmoteOnlyOff => UsageEmoteOnlyOff,
-            UsageEmoteOnlyOn => UsageEmoteOnlyOn,
-            UsageFollowersOff => UsageFollowersOff,
-            UsageFollowersOn => UsageFollowersOn,
-            UsageHelp => UsageHelp,
-            UsageHost => UsageHost,
-            UsageMarker => UsageMarker,
-            UsageMe => UsageMe,
-            UsageMod => UsageMod,
-            UsageMods => UsageMods,
-            UsageR9kOff => UsageR9kOff,
-            UsageR9kOn => UsageR9kOn,
-            UsageRaid => UsageRaid,
-            UsageSlowOff => UsageSlowOff,
-            UsageSlowOn => UsageSlowOn,
-            UsageSubsOff => UsageSubsOff,
-            UsageSubsOn => UsageSubsOn,
-            UsageTimeout => UsageTimeout,
-            UsageUnban => UsageUnban,
-            UsageUnhost => UsageUnhost,
-            UsageUnmod => UsageUnmod,
-            UsageUnraid => UsageUnraid,
-            UsageUntimeout => UsageUntimeout,
-            WhisperBanned => WhisperBanned,
-            WhisperBannedRecipient => WhisperBannedRecipient,
-            WhisperInvalidArgs => WhisperInvalidArgs,
-            WhisperInvalidLogin => WhisperInvalidLogin,
-            WhisperInvalidSelf => WhisperInvalidSelf,
-            WhisperLimitPerMin => WhisperLimitPerMin,
-            WhisperLimitPerSec => WhisperLimitPerSec,
-            WhisperRestricted => WhisperRestricted,
-            WhisperRestrictedRecipient => WhisperRestrictedRecipient,
-            Unknown(data) => Unknown(data.as_borrowed()),
-        }
-    }
-    fn as_owned(&self) -> Self::Owned {
-        use crate::messages::MessageId::*;
-        match self {
-            AlreadyBanned => AlreadyBanned,
-            AlreadyEmoteOnlyOff => AlreadyEmoteOnlyOff,
-            AlreadyEmoteOnlyOn => AlreadyEmoteOnlyOn,
-            AlreadyR9kOff => AlreadyR9kOff,
-            AlreadyR9kOn => AlreadyR9kOn,
-            AlreadySubsOff => AlreadySubsOff,
-            AlreadySubsOn => AlreadySubsOn,
-            BadBanAdmin => BadBanAdmin,
-            BadBanAnon => BadBanAnon,
-            BadBanBroadcaster => BadBanBroadcaster,
-            BadBanGlobalMod => BadBanGlobalMod,
-            BadBanMod => BadBanMod,
-            BadBanSelf => BadBanSelf,
-            BadBanStaff => BadBanStaff,
-            BadCommercialError => BadCommercialError,
-            BadDeleteMessageBroadcaster => BadDeleteMessageBroadcaster,
-            BadDeleteMessageMod => BadDeleteMessageMod,
-            BadHostError => BadHostError,
-            BadHostHosting => BadHostHosting,
-            BadHostRateExceeded => BadHostRateExceeded,
-            BadHostRejected => BadHostRejected,
-            BadHostSelf => BadHostSelf,
-            BadMarkerClient => BadMarkerClient,
-            BadModBanned => BadModBanned,
-            BadModMod => BadModMod,
-            BadSlowDuration => BadSlowDuration,
-            BadTimeoutAdmin => BadTimeoutAdmin,
-            BadTimeoutAnon => BadTimeoutAnon,
-            BadTimeoutBroadcaster => BadTimeoutBroadcaster,
-            BadTimeoutDuration => BadTimeoutDuration,
-            BadTimeoutGlobalMod => BadTimeoutGlobalMod,
-            BadTimeoutMod => BadTimeoutMod,
-            BadTimeoutSelf => BadTimeoutSelf,
-            BadTimeoutStaff => BadTimeoutStaff,
-            BadUnbanNoBan => BadUnbanNoBan,
-            BadUnhostError => BadUnhostError,
-            BadUnmodMod => BadUnmodMod,
-            BanSuccess => BanSuccess,
-            CmdsAvailable => CmdsAvailable,
-            ColorChanged => ColorChanged,
-            CommercialSuccess => CommercialSuccess,
-            DeleteMessageSuccess => DeleteMessageSuccess,
-            EmoteOnlyOff => EmoteOnlyOff,
-            EmoteOnlyOn => EmoteOnlyOn,
-            FollowersOff => FollowersOff,
-            FollowersOn => FollowersOn,
-            FollowersOnZero => FollowersOnZero,
-            HostOff => HostOff,
-            HostOn => HostOn,
-            HostSuccess => HostSuccess,
-            HostSuccessViewers => HostSuccessViewers,
-            HostTargetWentOffline => HostTargetWentOffline,
-            HostsRemaining => HostsRemaining,
-            InvalidUser => InvalidUser,
-            ModSuccess => ModSuccess,
-            MsgBanned => MsgBanned,
-            MsgBadCharacters => MsgBadCharacters,
-            MsgChannelBlocked => MsgChannelBlocked,
-            MsgChannelSuspended => MsgChannelSuspended,
-            MsgDuplicate => MsgDuplicate,
-            MsgEmoteonly => MsgEmoteonly,
-            MsgFacebook => MsgFacebook,
-            MsgFollowersonly => MsgFollowersonly,
-            MsgFollowersonlyFollowed => MsgFollowersonlyFollowed,
-            MsgFollowersonlyZero => MsgFollowersonlyZero,
-            MsgR9k => MsgR9k,
-            MsgRatelimit => MsgRatelimit,
-            MsgRejected => MsgRejected,
-            MsgRejectedMandatory => MsgRejectedMandatory,
-            MsgRoomNotFound => MsgRoomNotFound,
-            MsgSlowmode => MsgSlowmode,
-            MsgSubsonly => MsgSubsonly,
-            MsgSuspended => MsgSuspended,
-            MsgTimedout => MsgTimedout,
-            MsgVerifiedEmail => MsgVerifiedEmail,
-            NoHelp => NoHelp,
-            NoMods => NoMods,
-            NotHosting => NotHosting,
-            NoPermission => NoPermission,
-            R9kOff => R9kOff,
-            R9kOn => R9kOn,
-            RaidErrorAlreadyRaiding => RaidErrorAlreadyRaiding,
-            RaidErrorForbidden => RaidErrorForbidden,
-            RaidErrorSelf => RaidErrorSelf,
-            RaidErrorTooManyViewers => RaidErrorTooManyViewers,
-            RaidErrorUnexpected => RaidErrorUnexpected,
-            RaidNoticeMature => RaidNoticeMature,
-            RaidNoticeRestrictedChat => RaidNoticeRestrictedChat,
-            RoomMods => RoomMods,
-            SlowOff => SlowOff,
-            SlowOn => SlowOn,
-            SubsOff => SubsOff,
-            SubsOn => SubsOn,
-            TimeoutNoTimeout => TimeoutNoTimeout,
-            TimeoutSuccess => TimeoutSuccess,
-            TosBan => TosBan,
-            TurboOnlyColor => TurboOnlyColor,
-            UnbanSuccess => UnbanSuccess,
-            UnmodSuccess => UnmodSuccess,
-            UnraidErrorNoActiveRaid => UnraidErrorNoActiveRaid,
-            UnraidErrorUnexpected => UnraidErrorUnexpected,
-            UnraidSuccess => UnraidSuccess,
-            UnrecognizedCmd => UnrecognizedCmd,
-            UnsupportedChatroomsCmd => UnsupportedChatroomsCmd,
-            UntimeoutBanned => UntimeoutBanned,
-            UntimeoutSuccess => UntimeoutSuccess,
-            UsageBan => UsageBan,
-            UsageClear => UsageClear,
-            UsageColor => UsageColor,
-            UsageCommercial => UsageCommercial,
-            UsageDisconnect => UsageDisconnect,
-            UsageEmoteOnlyOff => UsageEmoteOnlyOff,
-            UsageEmoteOnlyOn => UsageEmoteOnlyOn,
-            UsageFollowersOff => UsageFollowersOff,
-            UsageFollowersOn => UsageFollowersOn,
-            UsageHelp => UsageHelp,
-            UsageHost => UsageHost,
-            UsageMarker => UsageMarker,
-            UsageMe => UsageMe,
-            UsageMod => UsageMod,
-            UsageMods => UsageMods,
-            UsageR9kOff => UsageR9kOff,
-            UsageR9kOn => UsageR9kOn,
-            UsageRaid => UsageRaid,
-            UsageSlowOff => UsageSlowOff,
-            UsageSlowOn => UsageSlowOn,
-            UsageSubsOff => UsageSubsOff,
-            UsageSubsOn => UsageSubsOn,
-            UsageTimeout => UsageTimeout,
-            UsageUnban => UsageUnban,
-            UsageUnhost => UsageUnhost,
-            UsageUnmod => UsageUnmod,
-            UsageUnraid => UsageUnraid,
-            UsageUntimeout => UsageUntimeout,
-            WhisperBanned => WhisperBanned,
-            WhisperBannedRecipient => WhisperBannedRecipient,
-            WhisperInvalidArgs => WhisperInvalidArgs,
-            WhisperInvalidLogin => WhisperInvalidLogin,
-            WhisperInvalidSelf => WhisperInvalidSelf,
-            WhisperLimitPerMin => WhisperLimitPerMin,
-            WhisperLimitPerSec => WhisperLimitPerSec,
-            WhisperRestricted => WhisperRestricted,
-            WhisperRestrictedRecipient => WhisperRestrictedRecipient,
-            Unknown(data) => Unknown(data.as_owned()),
-        }
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::decode::Message<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::decode::Message<T::Borrowed>;
-    type Owned = crate::decode::Message<T::Owned>;
-
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        crate::decode::Message {
-            raw: self.raw.as_borrowed(),
-            tags: self.tags.as_borrowed(),
-            prefix: self.prefix.as_borrowed(),
-            command: self.command.as_borrowed(),
-            args: self.args.as_borrowed(),
-            data: self.data.as_borrowed(),
-        }
-    }
-
-    fn as_owned(&self) -> Self::Owned {
-        crate::decode::Message {
-            raw: self.raw.as_owned(),
-            tags: self.tags.as_owned(),
-            prefix: self.prefix.as_owned(),
-            command: self.command.as_owned(),
-            args: self.args.as_owned(),
-            data: self.data.as_owned(),
-        }
-    }
-}
-
-impl<'a, T> Conversion<'a> for crate::decode::Prefix<T>
-where
-    T: StringMarker + Conversion<'a>,
-    <T as Conversion<'a>>::Borrowed: StringMarker,
-    <T as Conversion<'a>>::Owned: StringMarker,
-{
-    type Borrowed = crate::decode::Prefix<T::Borrowed>;
-    type Owned = crate::decode::Prefix<T::Owned>;
-
-    fn as_borrowed(&'a self) -> Self::Borrowed {
-        match self {
-            crate::decode::Prefix::User { nick } => crate::decode::Prefix::User {
-                nick: nick.as_borrowed(),
-            },
-            crate::decode::Prefix::Server { host } => crate::decode::Prefix::Server {
-                host: host.as_borrowed(),
-            },
-        }
-    }
-
+impl<'t> AsOwned for crate::decode::Prefix<'t> {
+    type Owned = crate::decode::Prefix<'static>;
     fn as_owned(&self) -> Self::Owned {
         match self {
             crate::decode::Prefix::User { nick } => crate::decode::Prefix::User {
@@ -678,90 +164,44 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn bool_conversion() {
-        let ok = false;
-        assert_eq!(ok.as_borrowed(), ok);
-        assert_eq!(ok.as_owned(), ok);
-    }
-
-    #[test]
-    fn usize_conversion() {
-        let ok = 42_usize;
-        assert_eq!(ok.as_borrowed(), ok);
-        assert_eq!(ok.as_owned(), ok);
-    }
-
-    #[test]
-    fn string_conversion() {
-        let owned = String::from("foobar");
-        let borrowed = "foobar";
-
-        assert_eq!(owned.as_borrowed(), borrowed);
-        assert_eq!(borrowed.as_owned(), owned);
-    }
-
-    #[test]
-    fn badge_conversion() {
-        let input_owned = crate::Badge {
-            kind: crate::BadgeKind::Unknown("foobar".to_string()),
-            data: "asdf".to_string(),
-        };
-
-        let input_borrowed = crate::Badge {
-            kind: crate::BadgeKind::Unknown("foobar"),
-            data: "asdf",
-        };
-
-        assert_eq!(input_owned.as_borrowed(), input_borrowed);
-        assert_eq!(input_borrowed.as_owned(), input_owned);
-
-        assert_eq!(input_owned.as_borrowed().as_owned(), input_owned);
-        assert_eq!(input_borrowed.as_owned().as_borrowed(), input_borrowed);
-    }
-
-    #[test]
-    #[allow(unused_qualifications)]
-    fn option_conversion() {
-        let owned = Some(String::from("asdf"));
-
-        assert_eq!(owned.as_borrowed(), Some("asdf"));
-        assert_eq!(Some("asdf").as_owned(), owned);
-
-        assert_eq!(Option::<String>::None.as_borrowed(), None);
-        assert_eq!(Option::<&'static str>::None.as_owned(), None);
-    }
-
-    #[test]
-    fn vec_conversion() {
-        let list = (b'a'..=b'z')
-            .map(|s| (s as char).to_string())
-            .map(Some)
-            .collect::<Vec<_>>();
-
-        let ref_ = list.iter().map(|s| s.as_deref()).collect::<Vec<_>>();
-
-        assert_eq!(list.as_borrowed(), ref_);
-        assert_eq!(ref_.as_owned(), list);
+impl<'t> AsOwned for crate::decode::Message<'t> {
+    type Owned = crate::decode::Message<'static>;
+    fn as_owned(&self) -> Self::Owned {
+        crate::decode::Message {
+            raw: self.raw.as_owned(),
+            tags: self.tags.as_owned(),
+            prefix: self.prefix.as_owned(),
+            command: self.command.as_owned(),
+            args: self.args.as_owned(),
+            data: self.data.as_owned(),
+        }
     }
 }
 
-pub(crate) mod private {
-    pub(crate) mod string_marker {
-        pub trait Sealed {}
-        impl<T> Sealed for T where T: crate::internal::StringMarker {}
-    }
-
-    pub(crate) mod parse_marker {
-        pub trait Sealed<E> {}
-        impl<T, E> Sealed<E> for T
-        where
-            T: crate::Parse<E>,
-            E: Sized,
-        {
+impl<'t> AsOwned for AllCommands<'t> {
+    type Owned = AllCommands<'static>;
+    fn as_owned(&self) -> Self::Owned {
+        match self {
+            AllCommands::Unknown(inner) => AllCommands::Unknown(inner.as_owned()),
+            AllCommands::Cap(inner) => AllCommands::Cap(inner.as_owned()),
+            AllCommands::ClearChat(inner) => AllCommands::ClearChat(inner.as_owned()),
+            AllCommands::ClearMsg(inner) => AllCommands::ClearMsg(inner.as_owned()),
+            AllCommands::GlobalUserState(inner) => AllCommands::GlobalUserState(inner.as_owned()),
+            AllCommands::HostTarget(inner) => AllCommands::HostTarget(inner.as_owned()),
+            AllCommands::IrcReady(inner) => AllCommands::IrcReady(inner.as_owned()),
+            AllCommands::Join(inner) => AllCommands::Join(inner.as_owned()),
+            AllCommands::Mode(inner) => AllCommands::Mode(inner.as_owned()),
+            AllCommands::Names(inner) => AllCommands::Names(inner.as_owned()),
+            AllCommands::Notice(inner) => AllCommands::Notice(inner.as_owned()),
+            AllCommands::Part(inner) => AllCommands::Part(inner.as_owned()),
+            AllCommands::Ping(inner) => AllCommands::Ping(inner.as_owned()),
+            AllCommands::Pong(inner) => AllCommands::Pong(inner.as_owned()),
+            AllCommands::Privmsg(inner) => AllCommands::Privmsg(inner.as_owned()),
+            AllCommands::Ready(inner) => AllCommands::Ready(inner.as_owned()),
+            AllCommands::Reconnect(inner) => AllCommands::Reconnect(inner.as_owned()),
+            AllCommands::RoomState(inner) => AllCommands::RoomState(inner.as_owned()),
+            AllCommands::UserNotice(inner) => AllCommands::UserNotice(inner.as_owned()),
+            AllCommands::UserState(inner) => AllCommands::UserState(inner.as_owned()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,9 @@ mod internal;
 /// Synchronous methods
 pub mod sync;
 
+#[doc(inline)]
+pub mod rate_limit;
+
 /// A trait for parsing messages
 ///
 /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
     unused_import_braces,
     unused_qualifications
 )]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 /*!
 This crate provides a way to interface with [Twitch]'s chat.
@@ -28,9 +27,12 @@ See `examples/demo.rs` for a demo of the api
 pub mod macros;
 
 cfg_async! {
+    use tokio::io::{AsyncRead, AsyncWrite};
+}
+
+cfg_async! {
     pub mod client;
-    #[doc(inline)]
-    pub use client::{Error, Client, EventStream};
+    pub use client::Client;
 }
 
 /// Decode messages from a `&str`
@@ -66,10 +68,6 @@ pub const TWITCH_WS_ADDRESS: &str = "ws://irc-ws.chat.twitch.tv:80";
 /// The Twitch WebSocket address for TLS connections
 pub const TWITCH_WS_ADDRESS_TLS: &str = "wss://irc-ws.chat.twitch.tv:443";
 
-cfg_async! {
-    use tokio::io::{AsyncRead, AsyncWrite};
-}
-
 /// Connection type
 ///
 /// Defaults to `Nope`
@@ -89,10 +87,10 @@ impl Default for Secure {
 
 impl Secure {
     /// Gets the requested (IRC) address
-    pub fn get_address(&self) -> &'static str {
+    pub fn get_address(self) -> &'static str {
         match self {
-            Secure::UseTls => TWITCH_IRC_ADDRESS_TLS,
-            Secure::Nope => TWITCH_IRC_ADDRESS,
+            Self::UseTls => TWITCH_IRC_ADDRESS_TLS,
+            Self::Nope => TWITCH_IRC_ADDRESS,
         }
     }
 }
@@ -115,10 +113,7 @@ cfg_async! {
     # });
     ```
     */
-    pub async fn register<W: ?Sized>(
-        user_config: &UserConfig,
-        writer: &mut W,
-    ) -> std::io::Result<()>
+    pub async fn register<W: ?Sized>(user_config: &UserConfig, writer: &mut W) -> std::io::Result<()>
     where
         W: AsyncWrite + Unpin,
     {
@@ -135,9 +130,9 @@ cfg_async! {
             writer.write_all(b"\r\n").await?;
         }
 
-        writer.write_all(format!("PASS {}\r\n", token).as_bytes()).await?;
-        writer.write_all(format!("NICK {}\r\n", name).as_bytes()).await?;
-
+        writer
+            .write_all(format!("PASS {}\r\nNICK {}\r\n", token,name).as_bytes())
+            .await?;
         Ok(())
     }
 }
@@ -145,9 +140,7 @@ cfg_async! {
 cfg_async! {
     const TWITCH_DOMAIN: &str = "irc.chat.twitch.tv";
 
-    type ConnectRes = std::io::Result<(
-        BoxAsyncRead, BoxAsyncWrite
-    )>;
+    type ConnectRes = std::io::Result<(BoxAsyncRead, BoxAsyncWrite)>;
 
     async fn connect_no_tls(addr: &str) -> std::io::Result<impl AsyncWrite + AsyncRead + Unpin> {
         tokio::net::TcpStream::connect(addr).await
@@ -198,10 +191,7 @@ cfg_async! {
     # });
     ```
     */
-    pub async fn connect(
-        user_config: &UserConfig,
-        secure: impl Into<Option<Secure>>,
-    ) -> ConnectRes {
+    pub async fn connect(user_config: &UserConfig, secure: impl Into<Option<Secure>>) -> ConnectRes {
         let secure = secure.into().unwrap_or_default();
         let addr = secure.get_address();
 
@@ -215,13 +205,13 @@ cfg_async! {
                 } else {
                     panic!("enable the \"tls\" feature to use this")
                 }
-            },
+            }
             Secure::Nope => {
                 let mut stream = connect_no_tls(addr).await?;
                 register(user_config, &mut stream).await?;
                 let (read, write) = tokio::io::split(stream);
                 Ok((Box::new(read), Box::new(write)))
-            },
+            }
         }
     }
 
@@ -302,38 +292,9 @@ pub const ANONYMOUS_LOGIN: (&str, &str) = (JUSTINFAN1234, JUSTINFAN1234);
 pub(crate) const JUSTINFAN1234: &str = "justinfan1234";
 
 mod internal;
-pub use internal::StringMarker;
 
 /// Synchronous methods
 pub mod sync;
-
-/// A trait for converting crate types between `Owned` and `Borrowed` representations
-///
-/// # Example
-/// ```rust
-/// # use twitchchat::*;
-/// # use twitchchat::messages::*;
-/// let input = ":test!test@test JOIN #museun\r\n";
-/// let message: Raw<&str> = decode::decode(&input).next().unwrap().unwrap();
-/// let message_owned: Raw<String> = message.as_owned();
-///
-/// let join: Join<&str> = Join::parse(&message).unwrap();
-/// let owned: Join<String> = join.as_owned();
-/// let borrowed: Join<&str> = join.as_borrowed();
-///
-/// assert_eq!(borrowed, join);
-/// ```
-pub trait Conversion<'a> {
-    /// The borrowed type
-    type Borrowed: 'a;
-    /// The owned type
-    type Owned;
-
-    /// Get a borrowed version
-    fn as_borrowed(&'a self) -> Self::Borrowed;
-    /// Get an owned version
-    fn as_owned(&self) -> Self::Owned;
-}
 
 /// A trait for parsing messages
 ///
@@ -341,16 +302,22 @@ pub trait Conversion<'a> {
 /// ```rust
 /// # use twitchchat::*;
 /// # use twitchchat::messages::*;
+/// # use std::borrow::Cow;
+///
 /// let input = ":test!test@test JOIN #museun\r\n";
-/// let message: Raw<&str> = decode::decode(&input).next().unwrap().unwrap();
-/// let join: Join<&str> = Join::parse(&message).unwrap();
-/// assert_eq!(join, Join { channel: "#museun", name: "test" });
+/// let message: Raw<'_> = decode::decode(&input).next().unwrap().unwrap();
+/// let join: Join<'_> = Join::parse(&message).unwrap();
+/// assert_eq!(join, Join { channel: Cow::Borrowed("#museun"), name: Cow::Borrowed("test") });
 /// ```
-pub trait Parse<T>
-where
-    Self: Sized,
-    Self: crate::internal::private::parse_marker::Sealed<T>,
-{
+pub trait Parse<T>: Sized + crate::internal::private::parse_marker::Sealed<T> {
     /// Tries to parse the input as this message
     fn parse(input: T) -> Result<Self, crate::messages::InvalidMessage>;
+}
+
+/// Converts a type to an owned version
+pub trait AsOwned: crate::internal::private::asowned_marker::Sealed {
+    /// The owned type
+    type Owned: 'static;
+    /// Get an owned version
+    fn as_owned(&self) -> Self::Owned;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,51 +10,10 @@ macro_rules! cfg_async {
     }
 }
 
-macro_rules! from_impl {
-    ($ty:tt) => {
-        impl<'a> From<$ty<&'a str>> for $ty<String> {
-            fn from(d: $ty<&'a str>) -> $ty<String> {
-                d.as_owned()
-            }
-        }
-
-        impl<'a> From<&$ty<&'a str>> for $ty<String> {
-            fn from(d: &$ty<&'a str>) -> $ty<String> {
-                d.as_owned()
-            }
-        }
-
-        impl<'a> From<&$ty<String>> for $ty<String> {
-            fn from(d: &$ty<String>) -> $ty<String> {
-                d.as_owned()
-            }
-        }
-
-        impl<'a> From<&'a $ty<&'a str>> for $ty<&'a str> {
-            fn from(d: &'a $ty<&'a str>) -> $ty<&'a str> {
-                d.as_borrowed()
-            }
-        }
-    };
-}
-
 macro_rules! conversion {
     ($ty:tt { $($field:ident),* $(,)? }) => {
-        impl<'a, T> Conversion<'a> for $ty<T>
-        where
-            T: StringMarker + Conversion<'a>,
-            <T as Conversion<'a>>::Borrowed: StringMarker,
-            <T as Conversion<'a>>::Owned: StringMarker,
-        {
-            type Owned = $ty<T::Owned>;
-            type Borrowed = $ty<T::Borrowed>;
-
-            fn as_borrowed(&'a self) -> Self::Borrowed {
-                $ty {
-                    $( $field: self.$field.as_borrowed(), )*
-                }
-            }
-
+        impl<'t> AsOwned for $ty<'t> {
+            type Owned = $ty<'static>;
             fn as_owned(&self) -> Self::Owned {
                 $ty {
                     $( $field: self.$field.as_owned(), )*
@@ -63,15 +22,8 @@ macro_rules! conversion {
         }
     };
     ($ty:tt) => {
-        impl<'a> Conversion<'a> for $ty
-        {
+        impl AsOwned for $ty {
             type Owned = $ty;
-            type Borrowed = $ty;
-
-            fn as_borrowed(&'a self) -> Self::Borrowed {
-                $ty { }
-            }
-
             fn as_owned(&self) -> Self::Owned {
                 $ty { }
             }
@@ -81,104 +33,24 @@ macro_rules! conversion {
 
 macro_rules! parse {
     (bare $ty:tt { $($field:ident),* $(,)? } => $body:expr) => {
-        impl<'a> Parse<&'a Message<&'a str>> for $ty<&'a str> {
-            fn parse(msg: &'a Message<&'a str>) -> Result<Self, InvalidMessage> {
+        impl<'a: 't, 't> Parse<&'a Message<'t>> for $ty<'t> {
+            fn parse(msg: &'a Message<'t>) -> Result<Self, InvalidMessage> {
                 $body(msg)
-            }
-        }
-
-        impl<'a> Parse<&'a Message<&'a str>> for $ty<String> {
-            fn parse(msg: &'a Message<&'a str>) -> Result<Self, InvalidMessage> {
-                $ty::<&'a str>::parse(msg).map(|ok| ok.as_owned())
             }
         }
     };
 
     ($ty:tt { $($field:ident),* $(,)? } => $body:expr) => {
         conversion!($ty { $($field,)* });
-        from_impl!($ty);
         parse!(bare $ty { $($field,)* } => $body);
     };
 
     ($ty:tt => $body:expr) => {
         conversion!($ty);
-
-        impl<'a> Parse<&'a Message<&'a str>> for $ty {
-            fn parse(msg: &'a Message<&'a str>) -> Result<Self, InvalidMessage> {
+        impl<'a: 't, 't> Parse<&'a Message<'t>> for $ty {
+            fn parse(msg: &'a Message<'t>) -> Result<Self, InvalidMessage> {
                 $body(msg)
             }
         }
-
-        impl<'a> Parse<&'a Message<String>> for $ty {
-            fn parse(msg: &'a Message<String>) -> Result<Self, InvalidMessage> {
-                $body(&msg.as_borrowed()).map(|ok| ok.as_owned())
-            }
-        }
     };
-}
-
-macro_rules! make_event {
-    (@DOC $($doc:expr)* => $item:tt) => {
-        $(#[doc = $doc])*
-        #[non_exhaustive]
-        #[allow(missing_debug_implementations,missing_copy_implementations)]
-        pub struct $item;
-    };
-
-    ($($event:ident => $message:path)*) => {
-        $(
-            make_event!(@DOC
-                concat!("Used to get a [", stringify!($message), "](../messages/struct.", stringify!($event), ".html)")
-                =>
-                $event
-            );
-
-            impl<'a> crate::client::Event<'a> for $event {
-                type Mapped = $message;
-            }
-        )*
-    };
-}
-
-macro_rules! make_mapping {
-    ($($event:expr => $ident:ident)*) => {
-        pub(crate) fn dispatch<'a>(&mut self, msg: &'a Message<&'a str>) {
-            match msg.command {
-                $($event => self.try_send::<events::$ident>(&msg),)*
-                _ => {},
-            }
-
-            self.try_send::<events::All>(&msg);
-            self.try_send::<events::Raw>(&msg);
-        }
-
-        pub(crate) fn new() -> Self {
-            Self { event_map: Default::default() }
-            $( .add_event::<events::$ident>() )*
-            .add_event::<events::All>()
-            .add_event::<events::Raw>()
-        }
-    };
-}
-
-macro_rules! export_modules_without_docs {
-    ($($module:ident)*) => {
-        $( #[allow(missing_docs)] mod $module; pub use $module::*; )*
-    };
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn from_borrowed() {
-        use crate::{Conversion, Parse};
-        let msg = crate::decode(":test!test@test JOIN #museun\r\n")
-            .next()
-            .unwrap()
-            .unwrap();
-
-        let join: crate::messages::Join<&str> = crate::messages::Join::parse(&msg).unwrap();
-        let join: crate::messages::Join<String> = join.into();
-        assert_eq!(join, join.as_owned());
-    }
 }

--- a/src/messages/error.rs
+++ b/src/messages/error.rs
@@ -2,7 +2,7 @@
 ///
 /// [Parse]: ../trait.Parse.html
 /// [Message]: ../decode/struct.Message.html
-/// [msg]: ./messages/index.html
+/// [msg]: ./index.html
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum InvalidMessage {
@@ -27,12 +27,12 @@ pub enum InvalidMessage {
 impl std::fmt::Display for InvalidMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InvalidMessage::InvalidCommand { expected, got } => {
+            Self::InvalidCommand { expected, got } => {
                 write!(f, "invalid command. got: {} expected {}", got, expected)
             }
-            InvalidMessage::ExpectedNick => f.write_str("expected nickname"),
-            InvalidMessage::ExpectedArg { pos } => write!(f, "expected arg at {}", pos),
-            InvalidMessage::ExpectedData => f.write_str("expected data"),
+            Self::ExpectedNick => f.write_str("expected nickname"),
+            Self::ExpectedArg { pos } => write!(f, "expected arg at {}", pos),
+            Self::ExpectedData => f.write_str("expected data"),
         }
     }
 }

--- a/src/messages/expect.rs
+++ b/src/messages/expect.rs
@@ -1,14 +1,15 @@
 use super::*;
+use std::borrow::Cow;
 
-pub(crate) trait Expect {
-    fn expect_command(&self, cmd: &str) -> Result<(), InvalidMessage>;
-    fn expect_nick(&self) -> Result<&str, InvalidMessage>;
-    fn expect_arg(&self, nth: usize) -> Result<&str, InvalidMessage>;
-    fn expect_data(&self) -> Result<&str, InvalidMessage>;
+pub(crate) trait Expect<'a, 'b: 'a> {
+    fn expect_command(&'b self, cmd: &'a str) -> Result<(), InvalidMessage>;
+    fn expect_nick(&'b self) -> Result<Cow<'a, str>, InvalidMessage>;
+    fn expect_arg(&'b self, nth: usize) -> Result<Cow<'a, str>, InvalidMessage>;
+    fn expect_data(&'b self) -> Result<&'a Cow<'a, str>, InvalidMessage>;
 }
 
-impl<'a> Expect for Message<&'a str> {
-    fn expect_command(&self, cmd: &str) -> Result<(), InvalidMessage> {
+impl<'a, 'b: 'a> Expect<'a, 'b> for Message<'a> {
+    fn expect_command(&'b self, cmd: &str) -> Result<(), InvalidMessage> {
         if self.command != cmd {
             return Err(InvalidMessage::InvalidCommand {
                 expected: cmd.to_string(),
@@ -18,7 +19,7 @@ impl<'a> Expect for Message<&'a str> {
         Ok(())
     }
 
-    fn expect_nick(&self) -> Result<&str, InvalidMessage> {
+    fn expect_nick(&'b self) -> Result<Cow<'a, str>, InvalidMessage> {
         self.prefix
             .as_ref()
             .and_then(|s| s.nick())
@@ -26,14 +27,17 @@ impl<'a> Expect for Message<&'a str> {
             .ok_or_else(|| InvalidMessage::ExpectedNick)
     }
 
-    fn expect_arg(&self, nth: usize) -> Result<&str, InvalidMessage> {
+    fn expect_arg(&'b self, nth: usize) -> Result<Cow<'a, str>, InvalidMessage> {
         self.args
             .split_whitespace()
             .nth(nth)
+            .map(Into::into)
             .ok_or_else(|| InvalidMessage::ExpectedArg { pos: nth })
     }
 
-    fn expect_data(&self) -> Result<&str, InvalidMessage> {
-        self.data.ok_or_else(|| InvalidMessage::ExpectedData)
+    fn expect_data(&'b self) -> Result<&'b Cow<'a, str>, InvalidMessage> {
+        self.data
+            .as_ref()
+            .ok_or_else(|| InvalidMessage::ExpectedData)
     }
 }

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1,82 +1,50 @@
 use super::*;
+use crate::Parse;
 
 #[test]
-fn raw_borrowed() {
+fn raw() {
     let input = ":museun!museun@museun.tmi.twitch.tv PRIVMSG #museun :testing over here\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Raw::<&str>::parse(&msg).unwrap(),
+            Raw::parse(&msg).unwrap(),
             Raw {
-                raw: input,
-                tags: Tags::default(),
-                prefix: Some(crate::decode::Prefix::User { nick: "museun" }),
-                command: "PRIVMSG",
-                args: "#museun",
-                data: Some("testing over here"),
-            }
-        )
-    }
-}
-
-#[test]
-fn raw_owned() {
-    let input = ":museun!museun@museun.tmi.twitch.tv PRIVMSG #museun :testing over here\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Raw::<String>::parse(&msg).unwrap(),
-            Raw {
-                raw: input.to_string(),
+                raw: input.into(),
                 tags: Tags::default(),
                 prefix: Some(crate::decode::Prefix::User {
-                    nick: "museun".to_string()
+                    nick: "museun".into()
                 }),
-                command: "PRIVMSG".to_string(),
-                args: "#museun".to_string(),
-                data: Some("testing over here".to_string()),
+                command: "PRIVMSG".into(),
+                args: "#museun".into(),
+                data: Some("testing over here".into()),
             }
         )
     }
 }
 
 #[test]
-fn user_notice_message_borrowed() {
+fn user_notice_message() {
     let input = ":tmi.twitch.tv USERNOTICE #museun :This room is no longer in slow mode.\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            UserNotice::<&str>::parse(&msg).unwrap(),
+            UserNotice::parse(&msg).unwrap(),
             UserNotice {
                 tags: Tags::default(),
-                channel: "#museun",
-                message: Some("This room is no longer in slow mode.")
+                channel: "#museun".into(),
+                message: Some("This room is no longer in slow mode.".into())
             }
         )
     }
 }
 
 #[test]
-fn user_notice_message_owned() {
-    let input = ":tmi.twitch.tv USERNOTICE #museun :This room is no longer in slow mode.\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            UserNotice::<String>::parse(&msg).unwrap(),
-            UserNotice {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                message: Some("This room is no longer in slow mode.".to_string())
-            }
-        )
-    }
-}
-
-#[test]
-fn user_notice_borrowed() {
+fn user_notice() {
     let input = ":tmi.twitch.tv USERNOTICE #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            UserNotice::<&str>::parse(&msg).unwrap(),
+            UserNotice::parse(&msg).unwrap(),
             UserNotice {
                 tags: Tags::default(),
-                channel: "#museun",
+                channel: "#museun".into(),
                 message: None,
             }
         )
@@ -84,60 +52,31 @@ fn user_notice_borrowed() {
 }
 
 #[test]
-fn user_notice_owned() {
-    let input = ":tmi.twitch.tv USERNOTICE #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            UserNotice::<String>::parse(&msg).unwrap(),
-            UserNotice {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                message: None,
-            }
-        )
-    }
-}
-
-#[test]
-fn room_state_borrowed() {
+fn room_state() {
     let input = ":tmi.twitch.tv ROOMSTATE #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            RoomState::<&str>::parse(&msg).unwrap(),
+            RoomState::parse(&msg).unwrap(),
             RoomState {
                 tags: Tags::default(),
-                channel: "#museun"
+                channel: "#museun".into()
             }
         )
     }
 }
 
 #[test]
-fn room_state_owned() {
-    let input = ":tmi.twitch.tv ROOMSTATE #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            RoomState::<String>::parse(&msg).unwrap(),
-            RoomState {
-                tags: Tags::default(),
-                channel: "#museun".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn names_start_borrowed() {
+fn names_start() {
     let input =
         ":museun!museun@museun.tmi.twitch.tv 353 museun = #museun :shaken_bot4 shaken_bot5\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Names::<&str>::parse(&msg).unwrap(),
+            Names::parse(&msg).unwrap(),
             Names {
-                name: "museun",
-                channel: "#museun",
+                name: "museun".into(),
+                channel: "#museun".into(),
                 kind: NamesKind::Start {
-                    users: vec!["shaken_bot4", "shaken_bot5"]
+                    users: vec!["shaken_bot4".into(), "shaken_bot5".into()]
                 }
             }
         )
@@ -145,32 +84,14 @@ fn names_start_borrowed() {
 }
 
 #[test]
-fn names_start_owned() {
-    let input =
-        ":museun!museun@museun.tmi.twitch.tv 353 museun = #museun :shaken_bot4 shaken_bot5\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Names::<String>::parse(&msg).unwrap(),
-            Names {
-                name: "museun".to_string(),
-                channel: "#museun".to_string(),
-                kind: NamesKind::Start {
-                    users: vec!["shaken_bot4".to_string(), "shaken_bot5".to_string()]
-                }
-            }
-        )
-    }
-}
-
-#[test]
-fn names_end_borrowed() {
+fn names_end() {
     let input = ":museun!museun@museun.tmi.twitch.tv 366 museun #museun :End of /NAMES list\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Names::<&str>::parse(&msg).unwrap(),
+            Names::parse(&msg).unwrap(),
             Names {
-                name: "museun",
-                channel: "#museun",
+                name: "museun".into(),
+                channel: "#museun".into(),
                 kind: NamesKind::End
             }
         )
@@ -178,31 +99,16 @@ fn names_end_borrowed() {
 }
 
 #[test]
-fn names_end_owned() {
-    let input = ":museun!museun@museun.tmi.twitch.tv 366 museun #museun :End of /NAMES list\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Names::<String>::parse(&msg).unwrap(),
-            Names {
-                name: "museun".to_string(),
-                channel: "#museun".to_string(),
-                kind: NamesKind::End
-            }
-        )
-    }
-}
-
-#[test]
-fn global_user_state_borrowed() {
+fn global_user_state() {
     let input = "@badge-info=;badges=;color=#FF69B4;display-name=shaken_bot;emote-sets=0;user-id=241015868;user-type= :tmi.twitch.tv GLOBALUSERSTATE\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            GlobalUserState::<&str>::parse(&msg).unwrap(),
+            GlobalUserState::parse(&msg).unwrap(),
             GlobalUserState {
-                user_id: "241015868",
-                display_name: Some("shaken_bot"),
+                user_id: "241015868".into(),
+                display_name: Some("shaken_bot".into()),
                 color: "#FF69B4".parse().unwrap(),
-                emote_sets: vec!["0"],
+                emote_sets: vec!["0".into()],
                 badges: vec![],
             }
         )
@@ -210,48 +116,16 @@ fn global_user_state_borrowed() {
 }
 
 #[test]
-fn global_user_state_owned() {
-    let input = "@badge-info=;badges=;color=#FF69B4;display-name=shaken_bot;emote-sets=0;user-id=241015868;user-type= :tmi.twitch.tv GLOBALUSERSTATE\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            GlobalUserState::<String>::parse(&msg).unwrap(),
-            GlobalUserState {
-                user_id: "241015868".to_string(),
-                display_name: Some("shaken_bot".to_string()),
-                color: "#FF69B4".parse().unwrap(),
-                emote_sets: vec!["0".to_string()],
-                badges: vec![],
-            }
-        )
-    }
-}
-
-#[test]
-fn host_target_borrowed() {
+fn host_target() {
     let input = ":tmi.twitch.tv HOSTTARGET #shaken_bot #museun 1024\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            HostTarget::<&str>::parse(&msg).unwrap(),
+            HostTarget::parse(&msg).unwrap(),
             HostTarget {
-                source: "#shaken_bot",
-                viewers: Some(1024),
-                kind: HostTargetKind::Start { target: "#museun" },
-            }
-        )
-    }
-}
-
-#[test]
-fn host_target_owned() {
-    let input = ":tmi.twitch.tv HOSTTARGET #shaken_bot #museun 1024\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            HostTarget::<String>::parse(&msg).unwrap(),
-            HostTarget {
-                source: "#shaken_bot".to_string(),
+                source: "#shaken_bot".into(),
                 viewers: Some(1024),
                 kind: HostTargetKind::Start {
-                    target: "#museun".to_string()
+                    target: "#museun".into()
                 },
             }
         )
@@ -259,31 +133,16 @@ fn host_target_owned() {
 }
 
 #[test]
-fn host_target_none_borrowed() {
+fn host_target_none() {
     let input = ":tmi.twitch.tv HOSTTARGET #shaken_bot #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            HostTarget::<&str>::parse(&msg).unwrap(),
+            HostTarget::parse(&msg).unwrap(),
             HostTarget {
-                source: "#shaken_bot",
-                viewers: None,
-                kind: HostTargetKind::Start { target: "#museun" },
-            }
-        )
-    }
-}
-
-#[test]
-fn host_target_none_owned() {
-    let input = ":tmi.twitch.tv HOSTTARGET #shaken_bot #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            HostTarget::<String>::parse(&msg).unwrap(),
-            HostTarget {
-                source: "#shaken_bot".to_string(),
+                source: "#shaken_bot".into(),
                 viewers: None,
                 kind: HostTargetKind::Start {
-                    target: "#museun".to_string()
+                    target: "#museun".into()
                 },
             }
         )
@@ -291,7 +150,7 @@ fn host_target_none_owned() {
 }
 
 #[test]
-fn cap_acknowledged_borrowed() {
+fn cap_acknowledged() {
     let input = ":tmi.twitch.tv CAP * ACK :twitch.tv/membership\r\n\
                  :tmi.twitch.tv CAP * ACK :twitch.tv/tags\r\n\
                  :tmi.twitch.tv CAP * ACK :twitch.tv/commands\r\n";
@@ -304,91 +163,46 @@ fn cap_acknowledged_borrowed() {
         .map(|s| s.unwrap())
         .zip(expected.into_iter())
     {
-        let msg = Cap::<&str>::parse(&msg).unwrap();
+        let msg = Cap::parse(&msg).unwrap();
         assert!(msg.acknowledged);
         assert_eq!(msg.capability, *expected);
     }
 }
 
 #[test]
-fn cap_acknowledged_owned() {
-    let input = ":tmi.twitch.tv CAP * ACK :twitch.tv/membership\r\n\
-                 :tmi.twitch.tv CAP * ACK :twitch.tv/tags\r\n\
-                 :tmi.twitch.tv CAP * ACK :twitch.tv/commands\r\n";
-    let expected = &[
-        "twitch.tv/membership",
-        "twitch.tv/tags",
-        "twitch.tv/commands",
-    ];
-    for (msg, expected) in crate::decode(&input)
-        .map(|s| s.unwrap())
-        .zip(expected.into_iter())
-    {
-        let msg = Cap::<String>::parse(&msg).unwrap();
-        assert!(msg.acknowledged);
-        assert_eq!(msg.capability, *expected);
-    }
-}
-
-#[test]
-fn cap_failed_borrowed() {
+fn cap_failed() {
     let input = ":tmi.twitch.tv CAP * NAK :foobar\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
-        let cap = Cap::<&str>::parse(&msg).unwrap();
+        let cap = Cap::parse(&msg).unwrap();
         assert!(!cap.acknowledged);
         assert_eq!(cap.capability, "foobar");
     }
 }
 
 #[test]
-fn cap_failed_owned() {
-    let input = ":tmi.twitch.tv CAP * NAK :foobar\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        let cap = Cap::<String>::parse(&msg).unwrap();
-        assert!(!cap.acknowledged);
-        assert_eq!(cap.capability, "foobar".to_string());
-    }
-}
-
-#[test]
-fn clear_chat_borrowed() {
+fn clear_chat() {
     let input = ":tmi.twitch.tv CLEARCHAT #museun :shaken_bot\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            ClearChat::<&str>::parse(&msg).unwrap(),
+            ClearChat::parse(&msg).unwrap(),
             ClearChat {
                 tags: Tags::default(),
-                channel: "#museun",
-                name: Some("shaken_bot"),
+                channel: "#museun".into(),
+                name: Some("shaken_bot".into()),
             }
         )
     }
 }
 
 #[test]
-fn clear_chat_owned() {
-    let input = ":tmi.twitch.tv CLEARCHAT #museun :shaken_bot\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            ClearChat::<String>::parse(&msg).unwrap(),
-            ClearChat {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                name: Some("shaken_bot".to_string()),
-            }
-        )
-    }
-}
-
-#[test]
-fn clear_chat_empty_borrowed() {
+fn clear_chat_empty() {
     let input = ":tmi.twitch.tv CLEARCHAT #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            ClearChat::<&str>::parse(&msg).unwrap(),
+            ClearChat::parse(&msg).unwrap(),
             ClearChat {
                 tags: Tags::default(),
-                channel: "#museun",
+                channel: "#museun".into(),
                 name: None,
             }
         )
@@ -396,59 +210,29 @@ fn clear_chat_empty_borrowed() {
 }
 
 #[test]
-fn clear_chat_empty_owned() {
-    let input = ":tmi.twitch.tv CLEARCHAT #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            ClearChat::<String>::parse(&msg).unwrap(),
-            ClearChat {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                name: None,
-            }
-        )
-    }
-}
-
-#[test]
-fn clear_msg_borrowed() {
+fn clear_msg() {
     let input = ":tmi.twitch.tv CLEARMSG #museun :HeyGuys\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            ClearMsg::<&str>::parse(&msg).unwrap(),
+            ClearMsg::parse(&msg).unwrap(),
             ClearMsg {
                 tags: Tags::default(),
-                channel: "#museun",
-                message: Some("HeyGuys"),
+                channel: "#museun".into(),
+                message: Some("HeyGuys".into()),
             }
         )
     }
 }
 
 #[test]
-fn clear_msg_owned() {
-    let input = ":tmi.twitch.tv CLEARMSG #museun :HeyGuys\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            ClearMsg::<String>::parse(&msg).unwrap(),
-            ClearMsg {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                message: Some("HeyGuys".to_string()),
-            }
-        )
-    }
-}
-
-#[test]
-fn clear_msg_empty_borrowed() {
+fn clear_msg_empty() {
     let input = ":tmi.twitch.tv CLEARMSG #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            ClearMsg::<&str>::parse(&msg).unwrap(),
+            ClearMsg::parse(&msg).unwrap(),
             ClearMsg {
                 tags: Tags::default(),
-                channel: "#museun",
+                channel: "#museun".into(),
                 message: None,
             }
         )
@@ -456,54 +240,26 @@ fn clear_msg_empty_borrowed() {
 }
 
 #[test]
-fn clear_msg_empty_owned() {
-    let input = ":tmi.twitch.tv CLEARMSG #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            ClearMsg::<String>::parse(&msg).unwrap(),
-            ClearMsg {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                message: None,
-            }
-        )
-    }
-}
-
-#[test]
-fn irc_ready_borrowed() {
+fn irc_ready() {
     let input = ":tmi.twitch.tv 001 shaken_bot :Welcome, GLHF!\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            IrcReady::<&str>::parse(&msg).unwrap(),
+            IrcReady::parse(&msg).unwrap(),
             IrcReady {
-                nickname: "shaken_bot"
+                nickname: "shaken_bot".into()
             }
         )
     }
 }
 
 #[test]
-fn irc_ready_owned() {
-    let input = ":tmi.twitch.tv 001 shaken_bot :Welcome, GLHF!\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            IrcReady::<String>::parse(&msg).unwrap(),
-            IrcReady {
-                nickname: "shaken_bot".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn join_bad_command_borrowed() {
-    let input = crate::decode(":tmi.twitch.tv NOT_JOIN #foo\r\n")
+fn join_bad_command() {
+    let input = crate::decode(":tmi.twitch.tv NOT_JOIN #foo\r\n".into())
         .flatten()
         .next()
         .unwrap();
 
-    let err = Join::<&str>::parse(&input).unwrap_err();
+    let err = Join::parse(&input).unwrap_err();
     matches::matches!(
         err,
         InvalidMessage::InvalidCommand {..}
@@ -511,271 +267,136 @@ fn join_bad_command_borrowed() {
 }
 
 #[test]
-fn join_bad_nick_borrowed() {
-    let input = crate::decode(":tmi.twitch.tv JOIN #foo\r\n")
+fn join_bad_nick() {
+    let input = crate::decode(":tmi.twitch.tv JOIN #foo\r\n".into())
         .flatten()
         .next()
         .unwrap();
 
-    let err = Join::<&str>::parse(&input).unwrap_err();
+    let err = Join::parse(&input).unwrap_err();
     matches::matches!(err, InvalidMessage::ExpectedNick);
 }
 
 #[test]
-fn join_bad_channel_borrowed() {
-    let input = crate::decode(":tmi.twitch.tv JOIN\r\n")
+fn join_bad_channel() {
+    let input = crate::decode(":tmi.twitch.tv JOIN\r\n".into())
         .flatten()
         .next()
         .unwrap();
 
-    let err = Join::<&str>::parse(&input).unwrap_err();
+    let err = Join::parse(&input).unwrap_err();
     matches::matches!(err, InvalidMessage::ExpectedArg { pos: 0 });
 }
 
 #[test]
-fn join_bad_command_owned() {
-    let input = crate::decode(":tmi.twitch.tv NOT_JOIN #foo\r\n")
-        .flatten()
-        .next()
-        .unwrap();
-
-    let err = Join::<String>::parse(&input).unwrap_err();
-    matches::matches!(
-        err,
-        InvalidMessage::InvalidCommand {..}
-    );
-}
-
-#[test]
-fn join_bad_nick_owned() {
-    let input = crate::decode(":tmi.twitch.tv JOIN #foo\r\n")
-        .flatten()
-        .next()
-        .unwrap();
-
-    let err = Join::<String>::parse(&input).unwrap_err();
-    matches::matches!(err, InvalidMessage::ExpectedNick);
-}
-
-#[test]
-fn join_bad_channel_owned() {
-    let input = crate::decode(":tmi.twitch.tv JOIN\r\n")
-        .flatten()
-        .next()
-        .unwrap();
-
-    let err = Join::<String>::parse(&input).unwrap_err();
-    matches::matches!(err, InvalidMessage::ExpectedArg { pos: 0 });
-}
-
-#[test]
-fn join_borrowed() {
+fn join() {
     let input = ":test!test@test JOIN #foo\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Join::<&str>::parse(&msg).unwrap(),
+            Join::parse(&msg).unwrap(),
             Join {
-                name: "test",
-                channel: "#foo"
+                name: "test".into(),
+                channel: "#foo".into()
             }
         )
     }
 }
 
 #[test]
-fn join_owned() {
-    let input = ":test!test@test JOIN #foo\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Join::<String>::parse(&msg).unwrap(),
-            Join {
-                name: "test".to_string(),
-                channel: "#foo".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn mode_lost_borrowed() {
+fn mode_lost() {
     let input = ":jtv MODE #museun -o shaken_bot\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Mode::<&str>::parse(&msg).unwrap(),
+            Mode::parse(&msg).unwrap(),
             Mode {
-                channel: "#museun",
+                channel: "#museun".into(),
                 status: ModeStatus::Lost,
-                name: "shaken_bot"
+                name: "shaken_bot".into()
             }
         )
     }
 }
 
 #[test]
-fn mode_gained_borrowed() {
+fn mode_gained() {
     let input = ":jtv MODE #museun +o shaken_bot\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Mode::<&str>::parse(&msg).unwrap(),
+            Mode::parse(&msg).unwrap(),
             Mode {
-                channel: "#museun",
+                channel: "#museun".into(),
                 status: ModeStatus::Gained,
-                name: "shaken_bot",
+                name: "shaken_bot".into(),
             }
         )
     }
 }
 
 #[test]
-fn mode_lost_owned() {
-    let input = ":jtv MODE #museun -o shaken_bot\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Mode::<String>::parse(&msg).unwrap(),
-            Mode {
-                channel: "#museun".to_string(),
-                status: ModeStatus::Lost,
-                name: "shaken_bot".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn mode_gained_owned() {
-    let input = ":jtv MODE #museun +o shaken_bot\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Mode::<String>::parse(&msg).unwrap(),
-            Mode {
-                channel: "#museun".to_string(),
-                status: ModeStatus::Gained,
-                name: "shaken_bot".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn notice_borrowed() {
+fn notice() {
     let input = ":tmi.twitch.tv NOTICE #museun :This room is no longer in slow mode.\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Notice::<&str>::parse(&msg).unwrap(),
+            Notice::parse(&msg).unwrap(),
             Notice {
                 tags: Tags::default(),
-                channel: "#museun",
-                message: "This room is no longer in slow mode.",
+                channel: "#museun".into(),
+                message: "This room is no longer in slow mode.".into(),
             }
         )
     }
 }
 
 #[test]
-fn notice_owned() {
-    let input = ":tmi.twitch.tv NOTICE #museun :This room is no longer in slow mode.\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Notice::<String>::parse(&msg).unwrap(),
-            Notice {
-                tags: Tags::default(),
-                channel: "#museun".to_string(),
-                message: "This room is no longer in slow mode.".to_string(),
-            }
-        )
-    }
-}
-
-#[test]
-fn part_borrowed() {
+fn part() {
     let input = ":test!test@test PART #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Part::<&str>::parse(&msg).unwrap(),
+            Part::parse(&msg).unwrap(),
             Part {
-                name: "test",
-                channel: "#museun",
+                name: "test".into(),
+                channel: "#museun".into(),
             }
         )
     }
 }
 
 #[test]
-fn part_owned() {
-    let input = ":test!test@test PART #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Part::<String>::parse(&msg).unwrap(),
-            Part {
-                name: "test".to_string(),
-                channel: "#museun".to_string(),
-            }
-        )
-    }
-}
-
-#[test]
-fn ping_borrowed() {
+fn ping() {
     let input = "PING :1234567890\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Ping::<&str>::parse(&msg).unwrap(),
+            Ping::parse(&msg).unwrap(),
             Ping {
-                token: "1234567890"
+                token: "1234567890".into()
             }
         )
     }
 }
 
 #[test]
-fn ping_owned() {
-    let input = "PING :1234567890\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Ping::<String>::parse(&msg).unwrap(),
-            Ping {
-                token: "1234567890".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn pong_borrowed() {
+fn pong() {
     let input = "PONG :1234567890\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Pong::<&str>::parse(&msg).unwrap(),
+            Pong::parse(&msg).unwrap(),
             Pong {
-                token: "1234567890"
+                token: "1234567890".into()
             }
         )
     }
 }
 
 #[test]
-fn pong_owned() {
-    let input = "PONG :1234567890\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Pong::<String>::parse(&msg).unwrap(),
-            Pong {
-                token: "1234567890".to_string()
-            }
-        )
-    }
-}
-
-#[test]
-fn privmsg_borrowed() {
+fn privmsg() {
     let input = ":test!user@host PRIVMSG #museun :this is a test\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Privmsg::<&str>::parse(&msg).unwrap(),
+            Privmsg::parse(&msg).unwrap(),
             Privmsg {
-                name: "test",
-                channel: "#museun",
-                data: "this is a test",
+                name: "test".into(),
+                channel: "#museun".into(),
+                data: "this is a test".into(),
                 tags: Default::default(),
             }
         )
@@ -783,44 +404,15 @@ fn privmsg_borrowed() {
 }
 
 #[test]
-fn privmsg_owned() {
-    let input = ":test!user@host PRIVMSG #museun :this is a test\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Privmsg::<String>::parse(&msg).unwrap(),
-            Privmsg {
-                name: "test".to_string(),
-                channel: "#museun".to_string(),
-                data: "this is a test".to_string(),
-                tags: Default::default(),
-            }
-        )
-    }
-}
-
-#[test]
-fn ready_borrowed() {
+fn ready() {
     let input = ":tmi.twitch.tv 376 shaken_bot :>\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            Ready::<&str>::parse(&msg).unwrap(),
+            Ready::parse(&msg).unwrap(),
             Ready {
-                username: "shaken_bot",
+                username: "shaken_bot".into(),
             }
         )
-    }
-}
-
-#[test]
-fn ready_owned() {
-    let input = ":tmi.twitch.tv 376 shaken_bot :>\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            Ready::<String>::parse(&msg).unwrap(),
-            Ready {
-                username: "shaken_bot".to_string(),
-            }
-        );
     }
 }
 
@@ -833,13 +425,13 @@ fn reconnect() {
 }
 
 #[test]
-fn user_state_borrowed() {
+fn user_state() {
     let input = ":tmi.twitch.tv USERSTATE #museun\r\n";
     for msg in crate::decode(input).map(|s| s.unwrap()) {
         assert_eq!(
-            UserState::<&str>::parse(&msg).unwrap(),
+            UserState::parse(&msg).unwrap(),
             UserState {
-                channel: "#museun",
+                channel: "#museun".into(),
                 tags: Tags::default()
             }
         )
@@ -847,15 +439,9 @@ fn user_state_borrowed() {
 }
 
 #[test]
-fn user_state_owned() {
-    let input = ":tmi.twitch.tv USERSTATE #museun\r\n";
-    for msg in crate::decode(input).map(|s| s.unwrap()) {
-        assert_eq!(
-            UserState::<String>::parse(&msg).unwrap(),
-            UserState {
-                channel: "#museun".to_string(),
-                tags: Tags::default()
-            }
-        );
-    }
+fn user_notice_unknown() {
+    let input = "@badge-info=subscriber/8;badges=subscriber/6,bits/100;color=#59517B;display-name=lllAirJordanlll;emotes=;flags=;id=3198b02c-eaf4-4904-9b07-eb1b2b12ba50;login=lllairjordanlll;mod=0;msg-id=resub;msg-param-cumulative-months=8;msg-param-months=0;msg-param-should-share-streak=0;msg-param-sub-plan-name=Channel\\sSubscription\\s(giantwaffle);msg-param-sub-plan=1000;room-id=22552479;subscriber=1;system-msg=lllAirJordanlll\\ssubscribed\\sat\\sTier\\s1.\\sThey\'ve\\ssubscribed\\sfor\\s8\\smonths!;tmi-sent-ts=1580932171144;user-id=44979519;user-type= :tmi.twitch.tv USERNOTICE #giantwaffle\r\n";
+    let msg = crate::decode(input).next().unwrap().unwrap();
+    let msg = AllCommands::parse(&msg).unwrap();
+    eprintln!("{:#?}", msg);
 }

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -1,0 +1,240 @@
+/*!
+A simple leaky-bucket style token-based rate limiter
+This'll block the calling task if tokens aren't available
+
+## Example
+```rust
+# use twitchchat::rate_limit::*;
+# use std::time::Duration;
+# use futures::future::FutureExt as _;
+# use tokio::time::delay_for;
+# tokio::runtime::Runtime::new().unwrap().block_on(async move {
+let mut rate = RateLimit::empty(3, Duration::from_millis(10));
+assert_eq!(rate.take().await, 2);
+assert_eq!(rate.take().await, 1);
+assert_eq!(rate.take().await, 0);
+assert!(rate.take().now_or_never().is_none()); // we're blocking
+
+// give it some time to refill
+delay_for(Duration::from_millis(15)).await;
+assert_eq!(rate.take().await, 2); // we're unblocked
+# });
+```
+*/
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// A preset number of tokens as described by Twitch
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
+pub enum RateClass {
+    /// `20` per `30` seconds
+    Regular,
+    /// `100` per `30` seconds
+    Moderator,
+    /// `50` per `30` seconds
+    Known,
+    /// `7500` per `30` seconds
+    Verified,
+}
+
+impl RateClass {
+    /// Number of tickets available for this class
+    pub fn tickets(self) -> u64 {
+        match self {
+            Self::Regular => 20,
+            Self::Moderator => 100,
+            Self::Known => 50,
+            Self::Verified => 7500,
+        }
+    }
+
+    /// Period specified by Twitch
+    pub const fn period() -> Duration {
+        Duration::from_secs(30)
+    }
+}
+
+/// A leaky-bucket style token-based rate limiter
+#[derive(Debug, Clone)]
+pub struct RateLimit {
+    cap: u64,
+    bucket: Bucket,
+}
+
+impl RateLimit {
+    /// Create a rate limit from a RateClass
+    pub fn from_class(rate_class: RateClass) -> Self {
+        Self::empty(rate_class.tickets(), RateClass::period())
+    }
+
+    /// Create a new rate limiter of `capacity` with an `initial` number of
+    /// token and the `period` between refills
+    pub fn new(cap: u64, initial: u64, period: Duration) -> Self {
+        Self {
+            cap,
+            bucket: Bucket::new(cap, initial, period),
+        }
+    }
+
+    /// Create a new rate limiter that is pre-filled
+    ///
+    /// `cap` is the number of total tokens available
+    ///
+    /// `period` is how long it'll take to refill all of the tokens
+    pub fn full(cap: u64, period: Duration) -> Self {
+        Self {
+            cap,
+            bucket: Bucket::new(cap, cap, period),
+        }
+    }
+
+    /// Create am empty rate limiter
+    ///
+    /// `cap` is the number of total tokens available
+    ///
+    /// `period` is how long it'll take to refill all of the tokens
+    ///
+    /// This will block, at first, atleast one `period` until its filled
+    pub fn empty(cap: u64, period: Duration) -> Self {
+        Self {
+            cap,
+            bucket: Bucket::new(cap, 0, period),
+        }
+    }
+
+    /// Consume a specific ammount of tokens
+    ///
+    /// # Returns    
+    /// * Successful consumption (e.g. not blocking) will return how many tokens
+    ///   are left
+    /// * Failure to consume (e.g. out of tokens) will return a Duration of when
+    ///   the bucket will be refilled
+    pub fn consume(&mut self, tokens: u64) -> Result<u64, Duration> {
+        let Self { bucket, .. } = self;
+
+        let now = Instant::now();
+        if let Some(n) = bucket.refill(now) {
+            bucket.tokens = std::cmp::min(bucket.tokens + n, self.cap);
+        }
+
+        if tokens <= bucket.tokens {
+            bucket.tokens -= tokens;
+            bucket.backoff = 0;
+            return Ok(bucket.tokens);
+        }
+
+        let prev = bucket.tokens;
+        Err(bucket.estimate(tokens - prev, now))
+    }
+
+    /// Throttle the current task, consuming a specific amount of tokens and
+    /// possibly blocking until tokens are available
+    ///
+    /// # Returns
+    /// the amount of tokens remaining
+    pub async fn throttle(&mut self, tokens: u64) -> u64 {
+        loop {
+            match self.consume(tokens) {
+                Ok(rem) => return rem,
+                Err(time) => tokio::time::delay_for(time).await,
+            }
+        }
+    }
+
+    /// Take a single token, returning how many are available
+    ///
+    /// This'll block the task if none are available
+    #[inline]
+    pub async fn take(&mut self) -> u64 {
+        self.throttle(1).await
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Bucket {
+    tokens: u64,
+    backoff: u32,
+    next: Instant,
+    last: Instant,
+    quantum: u64,
+    period: Duration,
+}
+
+impl Bucket {
+    fn new(tokens: u64, initial: u64, period: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            tokens: initial,
+            backoff: 0,
+            next: now + period,
+            last: now,
+            quantum: tokens,
+            period,
+        }
+    }
+
+    fn refill(&mut self, now: Instant) -> Option<u64> {
+        if now < self.next {
+            return None;
+        }
+
+        let last = now.duration_since(self.last);
+        let periods = last.as_nanos().checked_div(self.period.as_nanos())? as u64;
+        self.last += self.period * (periods as u32);
+        self.next = self.last + self.period;
+        (periods * self.quantum).into()
+    }
+
+    fn estimate(&mut self, tokens: u64, now: Instant) -> Duration {
+        let until = self.next.duration_since(now);
+        let periods = (tokens.checked_add(self.quantum).unwrap() - 1) / self.quantum;
+        until + self.period * (periods as u32 - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::prelude::*;
+
+    #[test]
+    fn consume() {
+        let mut rate = RateLimit::full(10, Duration::from_secs(30));
+        assert_eq!(rate.consume(1).unwrap(), 9);
+        assert_eq!(rate.consume(3).unwrap(), 6);
+        assert_eq!(rate.consume(6).unwrap(), 0);
+        // less than equal incase the test machine is somehow super fast or OS
+        // clock resolution is in the microsecond range
+        assert!(rate.consume(1).unwrap_err() <= Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn throttle() {
+        tokio::time::pause();
+        let mut rate = RateLimit::full(10, Duration::from_secs(30));
+
+        let range = [(3, 7), (3, 4), (3, 1)];
+        for (take, amount) in range.iter().copied() {
+            assert_eq!(rate.throttle(take).now_or_never().unwrap(), amount)
+        }
+        assert!(rate.throttle(3).now_or_never().is_none());
+        tokio::time::advance(Duration::from_secs(31)).await;
+        assert_eq!(rate.throttle(3).now_or_never().unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn take() {
+        tokio::time::pause();
+        let mut rate = RateLimit::full(10, Duration::from_secs(30));
+
+        let range = 0..=9;
+        for tokens in range.clone().zip(range.rev()).map(|(_, r)| r) {
+            assert_eq!(rate.take().now_or_never().unwrap(), tokens)
+        }
+
+        assert!(rate.take().now_or_never().is_none());
+        tokio::time::advance(Duration::from_secs(31)).await;
+        assert_eq!(rate.take().now_or_never().unwrap(), 9);
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -76,7 +76,7 @@ let (nick, pass) = ANONYMOUS_LOGIN;
 let (read, write) = connect_easy(&nick, &pass).unwrap();
 ```
 
-[Capabilities]: ./enum.Capability.html
+[Capabilities]: ../enum.Capability.html
 [async]: ../fn.connect_easy.html
 */
 

--- a/src/twitch/capability.rs
+++ b/src/twitch/capability.rs
@@ -27,10 +27,10 @@ impl Capability {
     /// Encode this capability as a string, to be sent to the server
     pub fn encode_as_str(self) -> &'static str {
         match self {
-            Capability::Membership => "CAP REQ :twitch.tv/membership",
-            Capability::Tags => "CAP REQ :twitch.tv/tags",
-            Capability::Commands => "CAP REQ :twitch.tv/commands",
-            Capability::ChatRooms => "CAP REQ :twitch.tv/tags twitch.tv/commands",
+            Self::Membership => "CAP REQ :twitch.tv/membership",
+            Self::Tags => "CAP REQ :twitch.tv/tags",
+            Self::Commands => "CAP REQ :twitch.tv/commands",
+            Self::ChatRooms => "CAP REQ :twitch.tv/tags twitch.tv/commands",
         }
     }
 }

--- a/src/twitch/channel.rs
+++ b/src/twitch/channel.rs
@@ -15,15 +15,12 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::EmptyChannelName => f.write_str("empty channel name"),
+            Self::EmptyChannelName => f.write_str("empty channel name"),
         }
     }
 }
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+
+impl std::error::Error for Error {}
 
 /// A trait to convert types into [`Channel`](./struct.Channel.html)
 ///
@@ -50,7 +47,7 @@ where
 }
 
 impl Channel {
-    pub(crate) fn validate(name: impl ToString) -> Result<Channel, Error> {
+    pub(crate) fn validate(name: impl ToString) -> Result<Self, Error> {
         let name = name.to_string();
         if name.is_empty() {
             return Err(Error::EmptyChannelName);
@@ -60,9 +57,9 @@ impl Channel {
         let name = if !name.starts_with('#') {
             ["#", name.as_str()].concat()
         } else {
-            name.to_string()
+            name
         };
-        Ok(Channel(name))
+        Ok(Self(name))
     }
 }
 

--- a/src/twitch/color.rs
+++ b/src/twitch/color.rs
@@ -70,8 +70,8 @@ pub enum ParseError {
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParseError::InvalidHexString => f.write_str("invalid hex string"),
-            ParseError::UnknownColor => f.write_str("unknown color"),
+            Self::InvalidHexString => f.write_str("invalid hex string"),
+            Self::UnknownColor => f.write_str("unknown color"),
         }
     }
 }
@@ -108,7 +108,7 @@ pub struct RGB(pub u8, pub u8, pub u8);
 
 impl Default for RGB {
     fn default() -> Self {
-        RGB(0xFF, 0xFF, 0xFF)
+        Self(0xFF, 0xFF, 0xFF)
     }
 }
 
@@ -121,15 +121,15 @@ impl std::fmt::Display for RGB {
 
 impl RGB {
     /// The red field
-    pub fn red(self) -> u8 {
+    pub const fn red(self) -> u8 {
         self.0
     }
     /// The green field
-    pub fn green(self) -> u8 {
+    pub const fn green(self) -> u8 {
         self.1
     }
     /// The blue field
-    pub fn blue(self) -> u8 {
+    pub const fn blue(self) -> u8 {
         self.2
     }
 }
@@ -341,7 +341,7 @@ impl From<RGB> for TwitchColor {
             .iter()
             .find(|(_, color)| *color == rgb)
             .map(|&(color, _)| color)
-            .unwrap_or_else(|| TwitchColor::Turbo)
+            .unwrap_or_else(|| Self::Turbo)
     }
 }
 

--- a/src/twitch/emotes.rs
+++ b/src/twitch/emotes.rs
@@ -28,7 +28,7 @@ impl Emotes {
             get_parts(s, ':').and_then(|(head, tail)| {
                 let emotes = Self {
                     id: head.parse().ok()?,
-                    ranges: get_ranges(&tail).collect(),
+                    ranges: get_ranges(tail).collect(),
                 };
                 emotes.into()
             })

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -18,14 +18,10 @@ pub mod color;
 mod channel;
 pub use channel::{Channel, Error as ChannelError, IntoChannel};
 
-pub(crate) fn parse_emotes<T>(input: &T) -> Vec<Emotes>
-where
-    T: crate::StringMarker,
-{
-    Emotes::parse(input.as_ref()).collect()
+pub(crate) fn parse_emotes(input: &str) -> Vec<Emotes> {
+    Emotes::parse(input).collect()
 }
 
-// TODO make this work with the conversion trait
-pub(crate) fn parse_badges<'a>(input: &'a str) -> Vec<Badge<&'a str>> {
+pub(crate) fn parse_badges(input: &str) -> Vec<Badge<'_>> {
     input.split(',').filter_map(Badge::parse).collect()
 }

--- a/src/twitch/userconfig.rs
+++ b/src/twitch/userconfig.rs
@@ -68,11 +68,11 @@ pub enum UserConfigError {
 impl std::fmt::Display for UserConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UserConfigError::InvalidName => f.write_str("invalid name"),
-            UserConfigError::InvalidToken => {
+            Self::InvalidName => f.write_str("invalid name"),
+            Self::InvalidToken => {
                 f.write_str("invalid token. token must start with oauth: and be 36 characters")
             }
-            UserConfigError::PartialAnonymous => f.write_str(
+            Self::PartialAnonymous => f.write_str(
                 "user provided name or token provided when an anonymous login was requested",
             ),
         }
@@ -135,12 +135,12 @@ impl UserConfigBuilder {
     pub fn build(self) -> Result<UserConfig, UserConfigError> {
         let name = self
             .name
-            .filter(|s| validate_name(&s))
+            .filter(|s| validate_name(s))
             .ok_or_else(|| UserConfigError::InvalidName)?;
 
         let token = self
             .token
-            .filter(|s| validate_token(&s))
+            .filter(|s| validate_token(s))
             .ok_or_else(|| UserConfigError::InvalidToken)?;
 
         match (name.as_str(), token.as_str()) {
@@ -162,7 +162,7 @@ impl UserConfigBuilder {
 }
 
 #[inline]
-fn validate_name(s: &str) -> bool {
+const fn validate_name(s: &str) -> bool {
     !s.is_empty()
 }
 


### PR DESCRIPTION
This is preliminary work for switching from a a complex bound such as `<T : StringMarker = String>` to a simple lifetime bound `<'t>` and using a `Cow<'t, str>` internally.

The owned 'variant' can just be `Foo<'static>` rather than the tedious `Foo<String>` (without the need for the `Conversion` trait) while the borrowed form is just `Foo<'t>` compared to `Foo<&'a str>`.

This shouldn't require much changes for the users, unless they were storing the types. A simple addition of an <'static> bound to their types would allow for the upgrade.

There is a new trait (and method), `AsOwned::as_owned()` which does, semantically, the same thing as `Conversion::as_owned()`.

I also removed most of the macros and just manually implemented the types/traits. They were annoying to get synchronized with changes.

I'm hoping this is the last beta release.