### PR TITLE
v0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "twitchchat"
 edition       = "2018"
-version       = "0.10.3"
+version       = "0.11.0"
 authors       = ["museun <museun@outlook.com>"]
 keywords      = ["twitch", "irc", "async", "asynchronous", "tokio"]
 license       = "MIT OR Apache-2.0"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,7 +1,7 @@
 /* in your Cargo.toml
 [dependencies]
 # this crate
-twitchchat = "0.10"
+twitchchat = "0.11"
 
 # and now for tokio
 # macros allows you to use `#[tokio::main]` and `tokio::pin!` and `tokio::select!`

--- a/examples/retry.rs
+++ b/examples/retry.rs
@@ -1,3 +1,14 @@
+/* in your Cargo.toml
+[dependencies]
+# this crate
+twitchchat = "0.11"
+
+# and now for tokio
+# macros allows you to use `#[tokio::main]` and `tokio::pin!` and `tokio::select!`
+# rt-threaded gives you a multi-threaded runtime.
+tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
+*/
+
 use tokio::stream::StreamExt as _;
 
 // your twitch name. it should be associated with your oauth token

--- a/examples/simple_bot.rs
+++ b/examples/simple_bot.rs
@@ -1,7 +1,7 @@
 /* in your Cargo.toml
 [dependencies]
 # this crate
-twitchchat = "0.10"
+twitchchat = "0.11"
 
 # and now for tokio
 # macros allows you to use `#[tokio::main]` and `tokio::pin!` and `tokio::select!`

--- a/examples/wait_to_join.rs
+++ b/examples/wait_to_join.rs
@@ -1,7 +1,7 @@
 /* in your Cargo.toml
 [dependencies]
 # this crate
-twitchchat = "0.10"
+twitchchat = "0.11"
 
 # and now for tokio
 # macros allows you to use `#[tokio::main]` and `tokio::pin!` and `tokio::select!`


### PR DESCRIPTION
This reworks the runner internally.

Runner::run was changed to Runner::run_to_completion
And a Runner::run_with_retry was added.

Both run methods now require a Connector wrapper (just a factory function for how connection should happen.

Retry takes in a Connector and a RetryStrategy.

Connector wraps an async function that returns an `std::io::Result<AsyncRead+AsyncWrite>`

All of the public methods that returns &Cow now return owned Cow.

Added a wait_for_reconnect to Control which'll allow you to block until a reconnection has happened.
