### PR TITLE
Revert to v0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "twitchchat"
 edition       = "2018"
-version       = "0.11.2"
+version       = "0.11.1"
 authors       = ["museun <museun@outlook.com>"]
 keywords      = ["twitch", "irc", "async", "asynchronous", "tokio"]
 license       = "MIT OR Apache-2.0"

--- a/src/runner/status.rs
+++ b/src/runner/status.rs
@@ -7,5 +7,5 @@ pub enum Status {
     /// It ran to completion
     Eof,
     /// It was cancelled
-    Cancelled,
+    Canceled,
 }


### PR DESCRIPTION
This reverts to commit a822a3693f0203960018072db25e44a74ae57507.

Discarding d2c553e76baf7f774090f9c761b62df3aeb48583 becb0d62d8e4379e562727ecd1a80d442c257628

These changes would break the semver. I thought it was just a spelling change in comments, but it was a change in a variant name. (Also, the build broke because it didn't change the doc tests or unit tests.)