### PR TITLE
make parking-lot optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["async", "tokio_native_tls"]
-async   = ["tokio", "futures"]
+async   = ["tokio", "futures", "parking_lot"]
 
 tokio_native_tls = ["tokio", "futures", "tokio-native-tls", "native-tls"]
 tokio_rustls     = ["tokio", "futures", "tokio-rustls", "webpki-roots"]
@@ -27,7 +27,7 @@ log = "0.4.8"
 
 futures = { version = "0.3.5", optional = true, default-features = false }
 tokio   = { version = "0.2.21", optional = true, features = ["dns", "io-util", "stream", "sync", "tcp", "time", "macros"] }
-serde = { version = "1.0.111", optional = true, features = ["derive"] }
+serde   = { version = "1.0.114", optional = true, features = ["derive"] }
 
 # native tls
 tokio-native-tls  = { version = "0.1.0", optional = true }
@@ -35,14 +35,15 @@ native-tls        = { version = "0.2.4", optional = true }
 
 # rustls
 tokio-rustls = { version = "0.13.1", optional = true }
-webpki-roots = { version = "0.19.0", optional = true }
+webpki-roots = { version = "0.20.0", optional = true }
 
 # internal stuff
-parking_lot = "0.10.2"
+parking_lot = { version = "0.11.0", optional = true }
+
 
 [dev-dependencies]
 tokio       = { version = "0.2.21", features = ["test-util", "macros"] }
-tokio-test  = "0.2.1" # this is used for sequenced IO in the test
+tokio-test  = "0.2.1"
 doc-comment = "0.3.3"
 
 [[example]]


### PR DESCRIPTION
`parking-lot` was being used even without any features selected

Ideally, we'd rely on `tokio::sync::Mutex` for the `Dispatcher`'s internal maps but this makes selecting over different aspects of the dispatcher .. a bit annoying. The dispatcher shouldn't have much contention. It acquires a single lock to check a cache and then another lock to read the map -- so a blocking mutex is fine here, its mostly just used for +Sync and interior mutability.

Switching to an async mutex would require bumping the semver because functions would have to be async now.

In the actual v0.12.0 release, I want to remove this mutex entirely and use a lock-free immutable hashmap.