### PR TITLE
Fix crash while decoding messages with spaces only

### DIFF
--- a/src/decode/message.rs
+++ b/src/decode/message.rs
@@ -48,3 +48,17 @@ impl<'t> Message<'t> {
         self.args.split_whitespace().nth(nth)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_empty_spaces() {
+        for i in 0..10 {
+            let s = format!("{}\r\n", " ".repeat(i));
+            let msg = Message::parse(&s).unwrap_err();
+            assert!(matches!(msg, ParseError::EmptyMessage));
+        }
+    }
+}

--- a/src/decode/message.rs
+++ b/src/decode/message.rs
@@ -26,7 +26,8 @@ impl<'t> Message<'t> {
             return Err(ParseError::IncompleteMessage { pos: 0 });
         }
 
-        let input = &input.trim_start_matches(' ')[..input.len() - 2];
+        let input = &input.trim_start_matches(' ');
+        let input = &input[..input.len() - 2];
         if input.is_empty() {
             return Err(ParseError::EmptyMessage);
         }


### PR DESCRIPTION
The parser crashed on inputs containing only ≧ three spaces and a correct `\r\n` ending due to the index `input.len() - 2` being out of bounds of the trimmed input.