### PR TITLE
v0.12.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "twitchchat"
 edition       = "2018"
-version       = "0.12.2"
+version       = "0.12.3"
 authors       = ["museun <museun@outlook.com>"]
 keywords      = ["twitch", "irc", "async", "asynchronous", "tokio"]
 license       = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 log = "0.4.11"
 
 # just the futures traits
-futures-lite = "0.1.11"
+futures-lite = "1.0.0"
 
 # field pin projection
 pin-project-lite = "0.1.7"
@@ -29,7 +29,7 @@ pin-project-lite = "0.1.7"
 async-dup = "1.2.1"
 
 # message passing
-async-channel = "1.4.0"
+async-channel = "1.4.1"
 
 # for timing out futures
 futures-timer = "3.0.2"
@@ -42,8 +42,8 @@ serde = { version = "1.0.115", optional = true, features = ["derive"] }
 
 # optional runtimes (for TcpStream)
 # these use the futures AsyncWrite+AsyncRead
-async-io  = { version = "0.1.11", optional = true }
-smol      = { version = "0.3.3", optional = true }
+async-io  = { version = "0.2.5", optional = true }
+smol      = { version = "0.4.1", optional = true }
 async-tls = { version = "0.9.0", default-features = false, features = ["client"], optional = true } 
 # TODO look into what their features do. the ones they have enabled by default seem important
 async-std = { version = "1.6.3", optional = true }
@@ -60,7 +60,7 @@ native-tls       = { version = "0.2.4", optional = true }
 
 [dev-dependencies]
 anyhow         = "1.0.32"
-async-executor = { version = "0.1.2", default-features = false }
+async-executor = { version = "0.2.0", default-features = false }
 serde_json     = { version = "1.0.57", default-features = false, features = ["alloc"] }
 rmp-serde      = "0.14.4"
 

--- a/examples/async_io_demo.rs
+++ b/examples/async_io_demo.rs
@@ -167,9 +167,11 @@ fn main() -> anyhow::Result<()> {
         .detach();
 
         // you can encode all sorts of 'commands'
-        writer
-            .encode(commands::privmsg("#museun", "hello world!"))
-            .await?;
+        for channel in &channels {
+            writer
+                .encode(commands::privmsg(channel, "hello world!"))
+                .await?;
+        }
 
         println!("starting main loop");
         // your 'main loop'. you'll just call next_message() until you're done

--- a/examples/async_std_demo.rs
+++ b/examples/async_std_demo.rs
@@ -159,9 +159,12 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // you can encode all sorts of 'commands'
-    writer
-        .encode(commands::privmsg("#museun", "hello world!"))
-        .await?;
+
+    for channel in &channels {
+        writer
+            .encode(commands::privmsg(channel, "hello world!"))
+            .await?;
+    }
 
     println!("starting main loop");
     // your 'main loop'. you'll just call next_message() until you're done

--- a/examples/simple_bot.rs
+++ b/examples/simple_bot.rs
@@ -38,7 +38,7 @@ fn main() -> anyhow::Result<()> {
         });
 
     // run the bot in the executor
-    smol::run(async move { bot.run(&user_config, &channels).await })
+    smol::block_on(async move { bot.run(&user_config, &channels).await })
 }
 
 struct Args<'a, 'b: 'a> {

--- a/examples/smol_demo.rs
+++ b/examples/smol_demo.rs
@@ -141,12 +141,12 @@ fn main() -> anyhow::Result<()> {
         let mut writer = runner.writer();
 
         // spawn something off in the background that'll exit in 10 seconds
-        smol::Task::spawn({
+        smol::spawn({
             let mut writer = writer.clone();
             let channels = channels.clone();
             async move {
                 println!("in 10 seconds we'll exit");
-                smol::Timer::new(std::time::Duration::from_secs(10)).await;
+                smol::Timer::after(std::time::Duration::from_secs(10)).await;
 
                 // send one final message to all channels
                 for channel in channels {
@@ -170,5 +170,5 @@ fn main() -> anyhow::Result<()> {
         main_loop(runner).await
     };
 
-    smol::run(fut)
+    smol::block_on(fut)
 }

--- a/examples/smol_demo.rs
+++ b/examples/smol_demo.rs
@@ -161,9 +161,11 @@ fn main() -> anyhow::Result<()> {
         .detach();
 
         // you can encode all sorts of 'commands'
-        writer
-            .encode(commands::privmsg("#museun", "hello world!"))
-            .await?;
+        for channel in &channels {
+            writer
+                .encode(commands::privmsg(channel, "hello world!"))
+                .await?;
+        }
 
         println!("starting main loop");
         // your 'main loop'. you'll just call next_message() until you're done

--- a/examples/tokio_demo.rs
+++ b/examples/tokio_demo.rs
@@ -159,9 +159,11 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // you can encode all sorts of 'commands'
-    writer
-        .encode(commands::privmsg("#museun", "hello world!"))
-        .await?;
+    for channel in &channels {
+        writer
+            .encode(commands::privmsg(channel, "hello world!"))
+            .await?;
+    }
 
     println!("starting main loop");
     // your 'main loop'. you'll just call next_message() until you're done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #![cfg_attr(docsrs, feature(doc_alias))]
 /*!
 
-This crate provides a way to interface with [Twitch]'s chat (via IRC).
+This crate provides a way to interface with [Twitch](https://dev.twitch.tv/docs/irc)'s chat (via IRC).
 
 Along with the messages as Rust types, it provides methods for sending messages.
 
@@ -49,7 +49,6 @@ For just encoding messages:
 * [encoder]
 ---
 
-[Twitch]: https://www.twitch.tv
 [runner]: runner/index.html
 [encoder]: encoder/index.html
 [decoder]: decoder/index.html

--- a/src/runner/async_runner.rs
+++ b/src/runner/async_runner.rs
@@ -95,7 +95,7 @@ impl AsyncRunner {
         .await?;
         log::debug!("connection is ready: {:?}", identity);
 
-        let (writer_tx, writer_rx) = crate::channel::bounded(64);
+        let (writer_tx, writer_rx) = crate::channel::unbounded();
         let (notify, notify_handle) = Notify::new();
         let (activity_tx, activity_rx) = crate::channel::bounded(32);
 

--- a/src/writer/mpsc_writer.rs
+++ b/src/writer/mpsc_writer.rs
@@ -134,5 +134,11 @@ mod tests {
 
         assert!(m.flush().is_ok());
         assert!(rx.try_recv().is_none());
+
+        assert!(m.buf.is_empty());
+
+        let _ = m.write(b"\r\n").unwrap();
+        assert!(m.flush().is_ok());
+        assert_eq!(&*rx.try_recv().unwrap(), b"\r\n");
     }
 }


### PR DESCRIPTION
This fixes a problem of double flushing an `MpscWriter`

This also upgrades the smol et.al family of deps and fixes the examples to use their new APIs.