### PR TITLE
0.14.0-pre

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ async = [
 log = { version = "0.4", optional = true }
 
 # just the futures traits
-futures-lite = { version = "1.8", optional = true }
+futures-lite = { version = "1.8", optional = true, default-features = false }
 
 # field pin projection
 pin-project-lite = { version = "0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "twitchchat"
 edition       = "2018"
-version       = "0.13.4"
+version       = "0.14.0"
 authors       = ["museun <museun@outlook.com>"]
 keywords      = ["twitch", "irc", "async", "asynchronous", "tokio"]
 license       = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,52 +29,52 @@ async = [
 
 [dependencies]
 # logging support
-log = { version = "0.4.11", optional = true }
+log = { version = "0.4", optional = true }
 
 # just the futures traits
-futures-lite = { version = "1.7.0", optional = true }
+futures-lite = { version = "1.8", optional = true }
 
 # field pin projection
-pin-project-lite = { version = "0.1.7", optional = true }
+pin-project-lite = { version = "0.1", optional = true }
 
 # cloneable async writes
-async-dup = { version = "1.2.2", optional = true }
+async-dup = { version = "1.2", optional = true }
 
 # message passing
-async-channel = { version = "1.4.2", optional = true }
+async-channel = { version = "1.4", optional = true }
 
 # for timing out futures
-futures-timer = { version = "3.0.2", optional = true }
+futures-timer = { version = "3.0", optional = true }
 
 # for 'fairness' in the main loop
-fastrand = { version = "1.3.5", optional = true }
+fastrand = { version = "1.3", optional = true }
 
 # for optional serialization and deserialization
-serde = { version = "1.0.116", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # optional runtimes (for TcpStream)
 # these use the futures AsyncWrite+AsyncRead
-async-io  = { version = "1.1.2", optional = true }
-smol      = { version = "1.1.0", optional = true }
-async-tls = { version = "0.10.0", default-features = false, features = ["client"], optional = true } 
+async-io  = { version = "1.1", optional = true }
+smol      = { version = "1.2", optional = true }
+async-tls = { version = "0.10", default-features = false, features = ["client"], optional = true } 
 # TODO look into what their features do. the ones they have enabled by default seem important
-async-std = { version = "1.6.4", optional = true }
+async-std = { version = "1.6", optional = true }
 
 # tokio has its own AsyncWrite+AsyncRead
-tokio            = { version = "0.2.22", features = ["net"], optional = true } 
-tokio-util       = { version = "0.3.1", features = ["compat"], optional = true }
+tokio            = { version = "0.2", features = ["net"], optional = true } 
+tokio-util       = { version = "0.3", features = ["compat"], optional = true }
 
-tokio-rustls     = { version = "0.14.1", optional = true }
-webpki-roots     = { version = "0.20.0", optional = true }
+tokio-rustls     = { version = "0.14", optional = true }
+webpki-roots     = { version = "0.20", optional = true }
 
-tokio-native-tls = { version = "0.1.0", optional = true }
-native-tls       = { version = "0.2.4", optional = true }
+tokio-native-tls = { version = "0.1", optional = true }
+native-tls       = { version = "0.2", optional = true }
 
 [dev-dependencies]
-anyhow         = "1.0.32"
-async-executor = { version = "1.3.0", default-features = false }
-serde_json     = "1.0.57"
-rmp-serde      = "0.14.4"
+anyhow         = "1.0"
+async-executor = { version = "1.3", default-features = false }
+serde_json     = "1.0"
+rmp-serde      = "0.14"
 
 [[example]]
 name = "message_parse"

--- a/examples/async_io_demo.rs
+++ b/examples/async_io_demo.rs
@@ -8,7 +8,8 @@ use crate::include::{channels_to_join, get_user_config, main_loop};
 async fn connect(user_config: &UserConfig, channels: &[String]) -> anyhow::Result<AsyncRunner> {
     // create a connector using ``async_io``, this connects to Twitch.
     // you can provide a different address with `custom`
-    let connector = connector::async_io::Connector::twitch();
+    // this can fail if DNS resolution cannot happen
+    let connector = connector::async_io::Connector::twitch().unwrap();
 
     println!("we're connecting!");
     // create a new runner. this is a provided async 'main loop'

--- a/examples/simple_bot.rs
+++ b/examples/simple_bot.rs
@@ -79,7 +79,8 @@ impl Bot {
 
     // run the bot until its done
     async fn run(&mut self, user_config: &UserConfig, channels: &[String]) -> anyhow::Result<()> {
-        let connector = twitchchat::connector::smol::Connector::twitch();
+        // this can fail if DNS resolution cannot happen
+        let connector = twitchchat::connector::smol::Connector::twitch().unwrap();
 
         let mut runner = AsyncRunner::connect(connector, user_config).await?;
         println!("connecting, we are: {}", runner.identity.username());

--- a/examples/smol_demo.rs
+++ b/examples/smol_demo.rs
@@ -8,7 +8,8 @@ use crate::include::{channels_to_join, get_user_config, main_loop};
 async fn connect(user_config: &UserConfig, channels: &[String]) -> anyhow::Result<AsyncRunner> {
     // create a connector using ``smol``, this connects to Twitch.
     // you can provide a different address with `custom`
-    let connector = connector::smol::Connector::twitch();
+    // this can fail if DNS resolution cannot happen
+    let connector = connector::smol::Connector::twitch().unwrap();
 
     println!("we're connecting!");
     // create a new runner. this is a provided async 'main loop'

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -266,6 +266,6 @@ where
     // said json doesn't live for long enough
     // okay.
     let whatever: &'static str = Box::leak(json.into_boxed_str());
-    let out = serde_json::from_str::<T>(&whatever).unwrap();
+    let out = serde_json::from_str::<T>(whatever).unwrap();
     assert_eq!(out, enc);
 }

--- a/src/commands/ban.rs
+++ b/src/commands/ban.rs
@@ -15,7 +15,9 @@ pub struct Ban<'a> {
 ///
 /// Reason is optional and will be shown to the target user and other moderators.
 ///
-/// Use [`unban`](./fn.unban.html) to remove a ban.
+/// Use [unban] to remove a ban.
+///
+/// [unban]: super::unban()
 pub fn ban<'a>(channel: &'a str, username: &'a str, reason: impl Into<Option<&'a str>>) -> Ban<'a> {
     Ban {
         channel,

--- a/src/commands/ban.rs
+++ b/src/commands/ban.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Permanently prevent a user from chatting.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Ban<'a> {

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Clear chat history for all users on `channel`.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Clear<'a> {

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,7 +1,7 @@
 use super::{Channel, Encodable};
 use std::io::{Result, Write};
 
-/// Clear chat history for all users in this room.
+/// Clear chat history for all users on `channel`.
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
@@ -9,7 +9,7 @@ pub struct Clear<'a> {
     pub(crate) channel: &'a str,
 }
 
-/// Clear chat history for all users in this room.
+/// Clear chat history for all users on `channel`.
 pub const fn clear(channel: &str) -> Clear<'_> {
     Clear { channel }
 }

--- a/src/commands/color.rs
+++ b/src/commands/color.rs
@@ -4,6 +4,7 @@ use std::io::{Result, Write};
 
 /// Change your username color.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Color<'a> {

--- a/src/commands/color.rs
+++ b/src/commands/color.rs
@@ -12,7 +12,8 @@ pub struct Color<'a> {
     marker: std::marker::PhantomData<&'a ()>,
 }
 
-/// Change your username color.
+/// Change your username `color`.
+// TODO documentation tests to show how you can use this with different types
 pub fn color<T>(color: T) -> std::result::Result<Color<'static>, T::Error>
 where
     T: TryInto<crate::twitch::Color>,

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Sends the `command` to the `channel` (e.g. `/color #FFFFFF`)
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Command<'a> {

--- a/src/commands/commercial.rs
+++ b/src/commands/commercial.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Triggers a commercial.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Commercial<'a> {

--- a/src/commands/disconnect.rs
+++ b/src/commands/disconnect.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Reconnects to chat.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Disconnect<'a> {

--- a/src/commands/emote_only.rs
+++ b/src/commands/emote_only.rs
@@ -13,7 +13,7 @@ pub struct EmoteOnly<'a> {
 ///
 /// Use [emote_only_off] to disable.
 ///
-/// [emote_only_off]: ./fn.emote_only_off.html
+/// [emote_only_off]: super::emote_only_off()
 pub const fn emote_only(channel: &str) -> EmoteOnly<'_> {
     EmoteOnly { channel }
 }

--- a/src/commands/emote_only.rs
+++ b/src/commands/emote_only.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Enables emote-only mode (only emoticons may be used in chat).
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct EmoteOnly<'a> {

--- a/src/commands/emote_only_off.rs
+++ b/src/commands/emote_only_off.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Disables emote-only mode.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct EmoteOnlyOff<'a> {

--- a/src/commands/followers.rs
+++ b/src/commands/followers.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Enables followers-only mode (only users who have followed for `duration` may chat).
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Followers<'a> {

--- a/src/commands/followers.rs
+++ b/src/commands/followers.rs
@@ -18,7 +18,7 @@ pub struct Followers<'a> {
 ///
 /// Use [followers_off] to disable.
 ///
-/// [followers_off]: ./fn.followers_off.html
+/// [followers_off]: super::followers_off()
 pub const fn followers<'a>(channel: &'a str, duration: &'a str) -> Followers<'a> {
     Followers { channel, duration }
 }

--- a/src/commands/followers_off.rs
+++ b/src/commands/followers_off.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Disables followers-only mode.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct FollowersOff<'a> {

--- a/src/commands/give_mod.rs
+++ b/src/commands/give_mod.rs
@@ -14,7 +14,7 @@ pub struct GiveMod<'a> {
 ///
 /// Use [mods] to list the moderators of this channel.
 ///
-/// [mods]: ./fn.mods.html
+/// [mods]: super::mods()
 pub const fn give_mod<'a>(channel: &'a str, username: &'a str) -> GiveMod<'a> {
     GiveMod { channel, username }
 }

--- a/src/commands/give_mod.rs
+++ b/src/commands/give_mod.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Grant moderator status to a user.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct GiveMod<'a> {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Lists the commands available to you in this room.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Help<'a> {

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Host another channel.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Host<'a> {

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -14,7 +14,7 @@ pub struct Host<'a> {
 ///
 /// Use [unhost] to unset host mode.
 ///
-/// [unhost]: ./struct.Encoder.html#method.unhost
+/// [unhost]: super::unhost()
 pub const fn host<'a>(source: &'a str, target: &'a str) -> Host<'a> {
     Host { source, target }
 }

--- a/src/commands/join.rs
+++ b/src/commands/join.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Join a channel. This handles prepending a leading '#' for you if you omit it.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Join<'a> {

--- a/src/commands/jtv_command.rs
+++ b/src/commands/jtv_command.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Sends the data as a command to the 'jtv' channel (e.g. `/color #FFFFFF`)
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct JtvCommand<'a> {

--- a/src/commands/marker.rs
+++ b/src/commands/marker.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Adds a stream marker (with an optional comment, **max 140** characters) at the current timestamp.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Marker<'a> {

--- a/src/commands/me.rs
+++ b/src/commands/me.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Sends an "emote" message in the third person to the channel
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Me<'a> {

--- a/src/commands/mods.rs
+++ b/src/commands/mods.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Lists the moderators of this channel.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Mods<'a> {

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Leave a channel. This handles prepending a leading '#' for you if you omit it.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Part<'a> {

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Request a servver response  with the provided token
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Ping<'a> {

--- a/src/commands/pong.rs
+++ b/src/commands/pong.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Respond to a server request (normally a PING) with the provided token
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Pong<'a> {

--- a/src/commands/privmsg.rs
+++ b/src/commands/privmsg.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Send a normal message to a channel
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Privmsg<'a> {

--- a/src/commands/r9k_beta.rs
+++ b/src/commands/r9k_beta.rs
@@ -4,6 +4,7 @@ use std::io::{Result, Write};
 
 /// Enables r9k mode.    
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct R9kBeta<'a> {

--- a/src/commands/r9k_beta.rs
+++ b/src/commands/r9k_beta.rs
@@ -14,7 +14,7 @@ pub struct R9kBeta<'a> {
 ///
 /// Use [r9k_beta_off] to disable.
 ///
-/// [r9k_beta_off]: ./fn.r9k_beta_off.html
+/// [r9k_beta_off]: super::r9k_beta_off()
 pub const fn r9k_beta(channel: &str) -> R9kBeta<'_> {
     R9kBeta { channel }
 }

--- a/src/commands/r9k_beta_off.rs
+++ b/src/commands/r9k_beta_off.rs
@@ -4,6 +4,7 @@ use std::io::{Result, Write};
 
 /// Disables r9k mode.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct R9kBetaOff<'a> {

--- a/src/commands/raid.rs
+++ b/src/commands/raid.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Raid another channel.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Raid<'a> {

--- a/src/commands/raid.rs
+++ b/src/commands/raid.rs
@@ -14,7 +14,7 @@ pub struct Raid<'a> {
 ///
 /// Use [unraid] to cancel the Raid.
 ///
-/// [unraid]: ./fn.unraid.html
+/// [unraid]: super::unraid()
 pub const fn raid<'a>(source: &'a str, target: &'a str) -> Raid<'a> {
     Raid { source, target }
 }

--- a/src/commands/raw.rs
+++ b/src/commands/raw.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Send a raw IRC-style message
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Raw<'a> {

--- a/src/commands/register.rs
+++ b/src/commands/register.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 
 /// Registers with Twitch. This writes the `UserConfig` out
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Register<'a> {

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -11,13 +11,6 @@ pub struct Reply<'a> {
     pub(crate) msg: &'a str,
 }
 
-// "reply-parent-display-name": "shaken_bot",
-// "reply-parent-msg-body": "hello\\smuseun!",
-// "reply-parent-msg-id": "1b136720-3a9a-4805-ab60-8c083e9f6fd2",
-// "reply-parent-user-id": "241015868",
-// "reply-parent-user-login": "shaken_bot",
-// "id": "2953829c-177c-42a3-9497-aed7ad916c78",
-
 /// Reply to a specific message (using an UUID) on a channel
 pub const fn reply<'a>(channel: &'a str, msg_id: &'a str, msg: &'a str) -> Reply<'a> {
     Reply {

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Reply to a specific message (using an UUID) on a channel
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Reply<'a> {

--- a/src/commands/slow.rs
+++ b/src/commands/slow.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Enables slow mode (limit how often users may send messages).
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Slow<'a> {

--- a/src/commands/slow.rs
+++ b/src/commands/slow.rs
@@ -16,7 +16,7 @@ pub struct Slow<'a> {
 ///
 /// Use [slow_off] to disable.
 ///
-/// [slow_off]: ./fn.slow_off.html
+/// [slow_off]: super::slow_off()
 pub fn slow(channel: &str, duration: impl Into<Option<usize>>) -> Slow<'_> {
     Slow {
         channel,

--- a/src/commands/slow_off.rs
+++ b/src/commands/slow_off.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Disables slow mode.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct SlowOff<'a> {

--- a/src/commands/subscribers.rs
+++ b/src/commands/subscribers.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Enables subscribers-only mode (only subscribers may chat in this channel).
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Subscribers<'a> {

--- a/src/commands/subscribers.rs
+++ b/src/commands/subscribers.rs
@@ -13,7 +13,7 @@ pub struct Subscribers<'a> {
 ///
 /// Use [subscribers_off] to disable.
 ///
-/// [subscribers_off]: ./fn.subscribers_off.html
+/// [subscribers_off]: super::subscribers_off()
 pub const fn subscribers(channel: &str) -> Subscribers<'_> {
     Subscribers { channel }
 }

--- a/src/commands/subscribers_off.rs
+++ b/src/commands/subscribers_off.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Disables subscribers-only mode.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct SubscribersOff<'a> {

--- a/src/commands/timeout.rs
+++ b/src/commands/timeout.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Temporarily prevent a user from chatting.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Timeout<'a> {

--- a/src/commands/timeout.rs
+++ b/src/commands/timeout.rs
@@ -29,7 +29,7 @@ pub struct Timeout<'a> {
 ///
 /// Use [untimeout] to remove a timeout.
 ///
-/// [untimeout]: ./fn.untimeout.html
+/// [untimeout]: super::untimeout()
 pub fn timeout<'a>(
     channel: &'a str,
     username: &'a str,

--- a/src/commands/unban.rs
+++ b/src/commands/unban.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Removes a ban on a user.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Unban<'a> {

--- a/src/commands/unhost.rs
+++ b/src/commands/unhost.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Stop hosting another channel.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Unhost<'a> {

--- a/src/commands/unmod.rs
+++ b/src/commands/unmod.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Revoke moderator status from a user.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Unmod<'a> {

--- a/src/commands/unmod.rs
+++ b/src/commands/unmod.rs
@@ -14,7 +14,7 @@ pub struct Unmod<'a> {
 ///
 /// Use [mods] to list the moderators of this channel.
 ///
-/// [mods]: ./fn.mods.html
+/// [mods]: super::mods()
 pub const fn unmod<'a>(channel: &'a str, username: &'a str) -> Unmod<'a> {
     Unmod { channel, username }
 }

--- a/src/commands/unraid.rs
+++ b/src/commands/unraid.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Cancel the raid.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Unraid<'a> {

--- a/src/commands/untimeout.rs
+++ b/src/commands/untimeout.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Removes a timeout on a user.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Untimeout<'a> {

--- a/src/commands/unvip.rs
+++ b/src/commands/unvip.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Revoke VIP status from a user.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Unvip<'a> {

--- a/src/commands/unvip.rs
+++ b/src/commands/unvip.rs
@@ -14,7 +14,7 @@ pub struct Unvip<'a> {
 ///
 /// Use [vips] to list the VIPs of this channel.
 ///
-/// [vips]: ./fn.vips.html
+/// [vips]: super::vips()
 pub const fn unvip<'a>(channel: &'a str, username: &'a str) -> Unvip<'a> {
     Unvip { channel, username }
 }

--- a/src/commands/vip.rs
+++ b/src/commands/vip.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Grant VIP status to a user.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Vip<'a> {

--- a/src/commands/vip.rs
+++ b/src/commands/vip.rs
@@ -14,7 +14,7 @@ pub struct Vip<'a> {
 ///
 /// Use [vips] to list the VIPs of this channel.
 ///
-/// [vips]: ./struct.Encoder.html#methodruct.html#method.vips
+/// [vips]: super::vips()
 pub const fn vip<'a>(channel: &'a str, username: &'a str) -> Vip<'a> {
     Vip { channel, username }
 }

--- a/src/commands/vips.rs
+++ b/src/commands/vips.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Lists the VIPs of this channel.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Vips<'a> {

--- a/src/commands/whisper.rs
+++ b/src/commands/whisper.rs
@@ -3,6 +3,7 @@ use std::io::{Result, Write};
 
 /// Whispers a message to the username.
 #[non_exhaustive]
+#[must_use = "commands must be encoded"]
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize))]
 pub struct Whisper<'a> {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -35,8 +35,8 @@ macro_rules! connector_ctor {
         #[doc = "Create a new"]
         $(#[$meta])*
         #[doc = "non-TLS connector that connects to the ***default Twitch*** address."]
-        pub fn twitch() -> Self {
-            Self::custom($crate::TWITCH_IRC_ADDRESS).expect("twitch DNS resolution")
+        pub fn twitch() -> ::std::io::Result<Self> {
+            Self::custom($crate::TWITCH_IRC_ADDRESS)
         }
 
         #[doc = "Create a new"]

--- a/src/connector/async_io/non_tls.rs
+++ b/src/connector/async_io/non_tls.rs
@@ -33,6 +33,6 @@ mod tests {
 
         assert_connector::<Connector>();
         assert_type_is_read_write::<<Connector as C>::Output>();
-        assert_obj_is_sane(Connector::twitch());
+        assert_obj_is_sane(Connector::twitch().unwrap());
     }
 }

--- a/src/connector/async_std/non_tls.rs
+++ b/src/connector/async_std/non_tls.rs
@@ -33,6 +33,6 @@ mod tests {
 
         assert_connector::<Connector>();
         assert_type_is_read_write::<<Connector as C>::Output>();
-        assert_obj_is_sane(Connector::twitch());
+        assert_obj_is_sane(Connector::twitch().unwrap());
     }
 }

--- a/src/connector/smol/non_tls.rs
+++ b/src/connector/smol/non_tls.rs
@@ -33,6 +33,6 @@ mod tests {
 
         assert_connector::<Connector>();
         assert_type_is_read_write::<<Connector as C>::Output>();
-        assert_obj_is_sane(Connector::twitch());
+        assert_obj_is_sane(Connector::twitch().unwrap());
     }
 }

--- a/src/connector/tokio/non_tls.rs
+++ b/src/connector/tokio/non_tls.rs
@@ -37,6 +37,6 @@ mod tests {
 
         assert_connector::<Connector>();
         assert_type_is_read_write::<<Connector as C>::Output>();
-        assert_obj_is_sane(Connector::twitch());
+        assert_obj_is_sane(Connector::twitch().unwrap());
     }
 }

--- a/src/decoder/async.rs
+++ b/src/decoder/async.rs
@@ -9,9 +9,9 @@ use std::{
 
 use futures_lite::{io::BufReader as AsyncBufReader, AsyncBufReadExt, AsyncRead, Stream};
 
-/// A decoder over `futures::io::AsyncRead` that produces `IrcMessage`s
+/// A decoder over [futures_lite::AsyncRead] that produces [IrcMessage]s
 ///
-/// This will return an `DecodeError::Eof` when its done reading manually.
+/// This will return an [DecodeError::Eof] when its done reading manually.
 ///
 /// When reading it as a stream, `Eof` will signal the end of the stream (e.g. `None`)
 pub struct AsyncDecoder<R> {
@@ -26,7 +26,7 @@ impl<R> std::fmt::Debug for AsyncDecoder<R> {
 }
 
 impl<R: AsyncRead + Send + Sync + Unpin> AsyncDecoder<R> {
-    /// Create a new AsyncDecoder from this `futures::io::Read` instance
+    /// Create a new AsyncDecoder from this [futures_lite::Read] instance
     pub fn new(reader: R) -> Self {
         Self {
             reader: AsyncBufReader::new(reader),
@@ -36,9 +36,9 @@ impl<R: AsyncRead + Send + Sync + Unpin> AsyncDecoder<R> {
 
     /// Read the next message.
     ///
-    /// This returns a borrowed IrcMessage which is valid until the next AsyncDecoder call is made.
+    /// This returns a borrowed [IrcMessage] which is valid until the next AsyncDecoder call is made.
     ///
-    /// If you just want an owned one, use the AsyncDecoder as an stream. e.g. dec.next().
+    /// If you just want an owned one, use the [AsyncDecoder] as an stream. e.g. dec.next().
     pub async fn read_message(&mut self) -> Result<IrcMessage<'_>, DecodeError> {
         self.buf.clear();
         let n = self

--- a/src/decoder/async.rs
+++ b/src/decoder/async.rs
@@ -26,7 +26,7 @@ impl<R> std::fmt::Debug for AsyncDecoder<R> {
 }
 
 impl<R: AsyncRead + Send + Sync + Unpin> AsyncDecoder<R> {
-    /// Create a new AsyncDecoder from this [futures_lite::Read] instance
+    /// Create a new AsyncDecoder from this [futures_lite::AsyncRead] instance
     pub fn new(reader: R) -> Self {
         Self {
             reader: AsyncBufReader::new(reader),

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,14 +1,14 @@
 //! Decoding utilities.
 //!
-//! A decoder lets you decode messages from an `std::io::Read` (or `futures::io::AsyncRead` for async) in either an iterative fashion, or one-by-one.
+//! A decoder lets you decode messages from an [std::io::Read] (or [futures_lite::AsyncRead] for async) in either an iterative fashion, or one-by-one.
 //!
 //! When not using the Iterator (or Stream), you'll get a borrowed message from the reader that is valid until the next read.
 //!
 //! With the Iterator (or Stream) interface, it'll return an owned messages.
 //!
 //! This crate provides both 'Sync' (Iterator based) and 'Async' (Stream based) decoding.
-//! * sync: [`Decoder`][decoder]
-//! * async: [`AsyncDecoder`][async_decoder]
+//! * sync: [Decoder]
+//! * async: [AsyncDecoder]
 //!
 //! # Borrowed messages
 //! ```
@@ -44,9 +44,6 @@
 //!     let msg: twitchchat::IrcMessage<'static> = msg.unwrap();
 //! }
 //! ```
-//! [decoder]: struct.Decoder.html
-//! [async_decoder]: struct.AsyncDecoder.html
-//!
 
 cfg_async! {
     mod r#async;

--- a/src/decoder/sync.rs
+++ b/src/decoder/sync.rs
@@ -37,9 +37,9 @@ impl std::error::Error for DecodeError {
     }
 }
 
-/// A decoder over `std::io::Read` that produces `IrcMessage`s
+/// A decoder over [std::io::Read] that produces [IrcMessage]s
 ///
-/// This will return an `DecodeError::Eof` when reading manually.
+/// This will return an [DecodeError::Eof] when reading manually.
 ///
 /// When reading it as a iterator, `Eof` will signal the end of the iterator (e.g. `None`)
 pub struct Decoder<R> {
@@ -57,7 +57,7 @@ impl<R> Decoder<R>
 where
     R: Read,
 {
-    /// Create a new Decoder from this `std::io::Read` instance
+    /// Create a new Decoder from this [std::io::Read] instance
     pub fn new(reader: R) -> Self {
         Self {
             reader: BufReader::new(reader),
@@ -67,9 +67,9 @@ where
 
     /// Read the next message.
     ///
-    /// This returns a borrowed IrcMessage which is valid until the next Decoder call is made.
+    /// This returns a borrowed [IrcMessage] which is valid until the next Decoder call is made.
     ///
-    /// If you just want an owned one, use the Decoder as an iterator. e.g. dec.next().
+    /// If you just want an owned one, use the [Decoder] as an iterator. e.g. dec.next().
     pub fn read_message(&mut self) -> Result<IrcMessage<'_>, DecodeError> {
         self.buf.clear();
         let n = self

--- a/src/encodable.rs
+++ b/src/encodable.rs
@@ -4,9 +4,9 @@ use std::{
     sync::Arc,
 };
 
-/// A trait to allow writing messags to any `std::io::Write` implementation
+/// A trait to allow writing messags to any [std::io::Write] implementation
 pub trait Encodable {
-    /// Encode this message to the provided `std::io::Write` implementation
+    /// Encode this message to the provided [std::io::Write] implementation
     fn encode<W>(&self, buf: &mut W) -> IoResult<()>
     where
         W: Write + ?Sized;

--- a/src/encoder/async.rs
+++ b/src/encoder/async.rs
@@ -71,7 +71,7 @@ impl<W> AsyncEncoder<W>
 where
     W: AsyncWrite + Send + Sync + Unpin,
 {
-    /// Create a new Encoder over this `futures::io::AsyncWrite` instance
+    /// Create a new Encoder over this [futures_lite::AsyncWrite] instance
     pub fn new(writer: W) -> Self {
         Self {
             writer,
@@ -80,7 +80,7 @@ where
         }
     }
 
-    /// Get the inner `futures::io::AsyncWrite` instance out
+    /// Get the inner [futures_lite::AsyncWrite] instance out
     ///
     /// This writes and flushes any buffered data before it consumes self.
     pub async fn into_inner(mut self) -> IoResult<W> {
@@ -94,7 +94,7 @@ where
         Ok(self.writer)
     }
 
-    /// Encode this `Encodable` message to the writer.
+    /// Encode this [Encodable](crate::Encodable) message to the writer.
     ///
     /// This flushes the data before returning
     pub async fn encode<M>(&mut self, msg: M) -> IoResult<()>

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -1,7 +1,7 @@
 //! # Encoding utilies
 //!
-//! ## Using the [`Encodable`][encodable] trait
-//! Many [`commands`][commands] are provided that can be encoded to a writer.
+//! ## Using the [Encodable](crate::Encodable) trait
+//! Many [commands](crate::commands) are provided that can be encoded to a writer.
 //!
 //! ```
 //! use twitchchat::{Encodable, commands};
@@ -19,7 +19,7 @@
 //! ```
 //!
 //! ## Using an Encoder
-//! This crate provides composable types (Writers/Encoders) which can be used with the [`Encodable`][encodable] trait.
+//! This crate provides composable types (Writers/Encoders) which can be used with the [Encodable](crate::Encodable) trait.
 //! The types come in both `Sync` and `Async` styles.
 //!
 //! ```
@@ -36,8 +36,6 @@
 //! let string = std::str::from_utf8(&buf).unwrap();
 //! assert_eq!(string, "JOIN #museun\r\nits also a writer\r\n");
 //! ```
-//! [encodable]: ../trait.Encodable.html
-//! [commands]: ../commands/index.html
 
 cfg_async! {
     mod r#async;

--- a/src/encoder/sync.rs
+++ b/src/encoder/sync.rs
@@ -16,17 +16,17 @@ impl<W> Encoder<W>
 where
     W: Write,
 {
-    /// Create a new Encoder over this `std::io::Write` instance
+    /// Create a new Encoder over this [std::io::Write] instance
     pub fn new(writer: W) -> Self {
         Self { writer }
     }
 
-    /// Get the inner `std::io::Write` instance out
+    /// Get the inner [std::io::Write] instance out
     pub fn into_inner(self) -> W {
         self.writer
     }
 
-    /// Encode this `Encodable` message to the writer and flushes it.
+    /// Encode this [Encodable] message to the writer and flushes it.
     pub fn encode<M>(&mut self, msg: M) -> IoResult<()>
     where
         M: Encodable,

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -88,7 +88,7 @@ pub fn parse_one(input: &str) -> Result<(usize, IrcMessage<'_>), MessageError> {
 
     let pos = input
         .find(CRLF)
-        .ok_or_else(|| MessageError::IncompleteMessage { pos: 0 })?
+        .ok_or(MessageError::IncompleteMessage { pos: 0 })?
         + CRLF.len();
 
     let next = &input[..pos];

--- a/src/irc/tags.rs
+++ b/src/irc/tags.rs
@@ -19,7 +19,7 @@ impl<'a> std::fmt::Debug for Tags<'a> {
 }
 
 impl<'a> Tags<'a> {
-    /// Build the tags view from this borrowed `Str` and an associated `TagIndices`
+    /// Build the tags view from this borrowed `MaybeOwned` and an associated `TagIndices`
     pub fn from_data_indices(data: &'a MaybeOwned<'a>, indices: &'a TagIndices) -> Self {
         Self { data, indices }
     }
@@ -61,11 +61,9 @@ impl<'a> Tags<'a> {
         self.indices.get(key.borrow(), &*self.data)
     }
 
-    /** Tries to get the tag as a parsable [`FromStr`] type.
+    /** Tries to get the tag as a parsable [std::str::FromStr] type.
 
     This returns None if it cannot parse, or cannot find the tag
-
-    [FromStr]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 
     ```rust
     # use twitchchat::{irc::{TagIndices, Tags}, maybe_owned::MaybeOwned};
@@ -167,7 +165,7 @@ impl<'a> IntoIterator for &'a Tags<'a> {
     }
 }
 
-/// An iterator over the Tags
+/// An iterator over the [Tags]
 #[derive(Clone)]
 pub struct TagsIter<'a> {
     inner: &'a Tags<'a>,
@@ -210,7 +208,7 @@ impl<'a> ::serde::Serialize for Tags<'a> {
     }
 }
 
-/// The reverse of [`escape_str`](#escape_str).
+/// The reverse of [escape_str].
 ///
 ///
 /// ```rust
@@ -219,7 +217,7 @@ impl<'a> ::serde::Serialize for Tags<'a> {
 /// assert_eq!(&*unescape_str(&*escape_str(s)), s);
 /// ```
 ///
-/// Use [`escape_str`](escape_str) to reverse this.
+/// Use [escape_str] to reverse this.
 /// ### Format
 ///
 /// | escaped              | character   |
@@ -264,7 +262,7 @@ pub fn unescape_str(s: &str) -> MaybeOwned<'_> {
 /// assert_eq!(&*unescape_str(&*escape_str(s)), s);
 /// ```
 ///
-/// Use [`unescape_str`](unescape_str) to reverse this.
+/// Use [unescape_str] to reverse this.
 /// ### Format
 ///
 /// | character   | escaped              |

--- a/src/irc/tags.rs
+++ b/src/irc/tags.rs
@@ -277,7 +277,7 @@ pub fn unescape_str(s: &str) -> MaybeOwned<'_> {
 /// [ref]: https://ircv3.net/specs/extensions/message-tags.html#escaping-values
 pub fn escape_str(s: &str) -> std::borrow::Cow<'_, str> {
     const NEEDS_ESCAPE: [char; 5] = [';', ' ', '\\', '\n', '\r'];
-    let n = s.chars().filter(|c| NEEDS_ESCAPE.contains(&c)).count();
+    let n = s.chars().filter(|c| NEEDS_ESCAPE.contains(c)).count();
     if n == 0 {
         return s.into();
     }
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn round_trip_escape() {
         let s = r"foo;bar and\foo\rwith\n";
-        assert_eq!(unescape_str(&*escape_str(&s)), s);
+        assert_eq!(unescape_str(&*escape_str(s)), s);
     }
 
     #[test]
@@ -421,8 +421,8 @@ mod tests {
             let indices = TagIndices::build_indices(&*data);
             let tags = Tags::from_data_indices(&data, &indices);
 
-            let v = tags.into_iter().collect::<Vec<_>>();
-            assert_eq!(v.len(), input.chars().filter(|&c| c == ';').count() + 1);
+            let len = tags.into_iter().count();
+            assert_eq!(len, input.chars().filter(|&c| c == ';').count() + 1);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,28 +21,27 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![cfg_attr(docsrs, feature(doc_cfg), feature(doc_alias))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+#![cfg_attr(docsrs, feature(broken_intra_doc_links))]
 /*!
 
 This crate provides a way to interface with [Twitch](https://dev.twitch.tv/docs/irc)'s chat (via IRC).
 
 Along with the messages as Rust types, it provides methods for sending messages.
-
 ---
 
 By default, this crate depends on zero external crates -- but it makes it rather limited in scope.
 
 This allows parsing, and decoding/encoding to standard trait types (`std::io::{Read, Write}`).
 
-To use the `AsyncRunner` (an async-event loop) and related helpers, you must able the `async` feature.
+To use the [AsyncRunner] (an async-event loop) and related helpers, you must able the `async` feature.
 
 ***NOTE*** This is a breaking change from `0.12` which had the async stuff enabled by default.
 
 ```toml
 twitchchat = { version = "0.13", features = ["async"] }
 ```
-To use a specific `TcpStream`/`TlStream` refer to the runtime table below.
-
 ---
 
 For twitch types:
@@ -61,15 +60,7 @@ For just decoding messages:
 ---
 For just encoding messages:
 * [encoder]
----
 
-[runner]: runner/index.html
-[encoder]: encoder/index.html
-[decoder]: decoder/index.html
-[twitch]: twitch/index.html
-[messages]: messages/index.html
-[commands]: commands/index.html
-[irc]: irc/index.html
 */
 
 macro_rules! cfg_async {
@@ -162,18 +153,3 @@ mod serde;
 mod util;
 
 pub use ext::PrivmsgExt;
-
-// /// Prelude with common types
-// pub mod prelude {
-//     pub use crate::irc::{IrcMessage, TagIndices, Tags};
-//     pub use crate::rate_limit::RateClass;
-//     pub use crate::Encodable;
-//     pub use crate::{commands, messages, twitch};
-//     pub use crate::{Decoder, Encoder};
-
-//     cfg_async! {
-//         pub use crate::decoder::AsyncDecoder;
-//         pub use crate::encoder::AsyncEncoder;
-//         pub use crate::runner::{AsyncRunner, Identity, NotifyHandle, Status};
-//     }
-// }

--- a/src/maybe_owned/maybe_owned_index.rs
+++ b/src/maybe_owned/maybe_owned_index.rs
@@ -3,7 +3,7 @@ use std::ops::{Index, Range};
 
 type IndexWidth = u16;
 
-/// An index into a `MaybeOwned`.
+/// An index into a [MaybeOwned].
 #[derive(Copy, Clone, Default, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct MaybeOwnedIndex {
     /// The start index

--- a/src/maybe_owned/mod.rs
+++ b/src/maybe_owned/mod.rs
@@ -1,10 +1,8 @@
-//! This is a [`Cow`][cow] like type used in this crate.
+//! This is a [std::borrow::Cow] like type used in this crate.
 //!
 //! It is read-only unlike the std implementation.
 //!
 //! Its also specialized for just `str`
-//!
-//! [cow]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
 use std::{fmt::Debug, ops::Deref};
 
 mod into_owned;

--- a/src/messages/cap.rs
+++ b/src/messages/cap.rs
@@ -90,7 +90,7 @@ mod tests {
             "twitch.tv/tags",
             "twitch.tv/commands",
         ];
-        for (msg, expected) in parse(&input).map(|s| s.unwrap()).zip(expected) {
+        for (msg, expected) in parse(input).map(|s| s.unwrap()).zip(expected) {
             let msg = Cap::from_irc(msg).unwrap();
             assert_eq!(msg.capability(), Capability::Acknowledged(*expected));
         }

--- a/src/messages/user_notice.rs
+++ b/src/messages/user_notice.rs
@@ -18,9 +18,7 @@ pub enum SubPlan<'a> {
     Unknown(&'a str),
 }
 
-/// The kind of notice it was, retrieved via [`UserNotice::msg_id`][msg_id]
-///
-/// [msg_id]: ./struct.UserNotice.html#method.msg_id
+/// The kind of notice it was, retrieved via [UserNotice::msg_id()]
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]

--- a/src/runner/channel.rs
+++ b/src/runner/channel.rs
@@ -12,6 +12,7 @@ use std::{
 ///
 /// # Warning
 /// You shouldn't need to touch this unless you have a good reason to do so.
+///
 /// Improperly using this could result in Twitch disconnecting you, at best and
 /// a ban at worst.
 pub struct Channel {
@@ -42,7 +43,7 @@ impl Channel {
         }
     }
 
-    /// Set the `RateClass` for this channel
+    /// Set the [RateClass] for this channel
     pub fn set_rate_class(&mut self, rate_class: RateClass) {
         self.rate_limited.rate_limit = RateLimit::from_class(rate_class);
         self.rated_limited_at.take();

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -5,7 +5,7 @@ use crate::{DecodeError, MessageError};
 pub enum Error {
     /// An I/O error occured
     Io(std::io::Error),
-    /// Invalid utf-8 was parsed (either you sent invalid utf-8, or twitch did and we read it).
+    /// Invalid utf-8 was parsed (either you sent invalid utf-8, or Twitch did and we read it).
     InvalidUtf8(std::str::Utf8Error),
     /// We could not parse a message -- this should never happen
     ParsingFailure(MessageError),

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,23 +1,14 @@
 //! A set of runners for managing a `event loop`
 //!
-//! To use the [`AsyncRunner`][async_runner]:
-//! 1. choose [`Connector`][connector] from [`connectors`][connectors].
-//! 1. create a [`UserConfig`][user_config].
-//! 1. create and connect the [`AsyncRunner`][async_runner] via its [`AsyncRunner::connect()`][connect] method
+//! To use the [AsyncRunner]:
+//! 1. choose [Connector](crate::connector::Connector) from [connectors](crate::connector).
+//! 1. create a [UserConfig](crate::UserConfig).
+//! 1. create and connect the [AsyncRunner] via its [AsyncRunner::connect()] method
 //! 1. now you're connected to Twitch, so next things you can do.
-//!     1. join a channel with: [`AsyncRunner::join()`][join],
-//!     1. write messages with the [`AsyncWriter`][async_writer] provided by [`AsyncRunner::writer()`][writer].
-//!     1. signal you want to quit with the [`AsyncRunner::quit_handle()`][quit]
+//!     1. join a channel with: [AsyncRunner::join()],
+//!     1. write messages with the [AsyncWriter](crate::writer::AsyncWriter) provided by [AsyncRunner::writer()].
+//!     1. signal you want to quit with the [AsyncRunner::quit_handle()]
 //!
-//! [async_runner]: struct.AsyncRunner.html
-//! [connector]: ../connector/trait.Connector.html
-//! [connectors]: ../connector/index.html
-//! [user_config]: ../twitch/struct.UserConfig.html
-//! [connect]: struct.AsyncRunner.html#method.connect
-//! [join]: struct.AsyncRunner.html#method.join
-//! [async_writer]: ../writer/struct.AsyncWriter.html
-//! [writer]: struct.AsyncRunner.html#method.writer
-//! [quit]: struct.AsyncRunner.html#method.quit_handle
 
 mod status;
 pub use status::{Status, StepResult};

--- a/src/test/tags_builder.rs
+++ b/src/test/tags_builder.rs
@@ -178,7 +178,7 @@ mod tests {
             (r"the_win_end\r", r"the_win_end\\r"),
         ];
         for (input, expected) in tests {
-            assert_eq!(tags::escape_str(&*input), *expected)
+            assert_eq!(tags::escape_str(*input), *expected)
         }
 
         let tests = &["dont_escape+me", "foo=1234"];

--- a/src/twitch/badge.rs
+++ b/src/twitch/badge.rs
@@ -1,9 +1,9 @@
 /// The kind of the [badges] that are associated with messages.
 ///
-/// Any unknonw (e.g. custom badges/sub events, etc) are placed into the [Unknown] variant.
+/// Any unknown (e.g. custom badges/sub events, etc) are placed into the [Unknown] variant.
 ///
-/// [badges]: ./struct.Badge.html
-/// [Unknown]: ./enum.BadgeKind.html#variant.Unknown
+/// [badges]: Badge
+/// [Unknown]: BadgeKind::Unknown
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]

--- a/src/twitch/capability.rs
+++ b/src/twitch/capability.rs
@@ -31,7 +31,7 @@ impl Capability {
 
     /// Attempts to 'parse' this capability from a string
     ///
-    /// This will take the form of `twitch.tv/$tag` and produce a `Capability`
+    /// This will take the form of `twitch.tv/$tag` and produce a [Capability]
     #[allow(dead_code)]
     pub(crate) fn maybe_from_str(input: &str) -> Option<Self> {
         match input {

--- a/src/twitch/color.rs
+++ b/src/twitch/color.rs
@@ -198,7 +198,7 @@ These can be [parsed] from their **name** in
 - `"snake_case"`
 - `"lower case"`
 
-[parsed]: https://doc.rust-lang.org/std/str/trait.FromStr.html
+[parsed]: std::str::FromStr
 */
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
@@ -258,7 +258,7 @@ impl FromStr for Color {
 impl Default for Color {
     /// Defaults to having a kind of [Turbo] and RGB of #FFFFFF (white)
     ///
-    /// [Turbo]: ./enum.TwitchColor.html#variant.Turbo
+    /// [Turbo]: TwitchColor::Turbo
     fn default() -> Self {
         Self {
             kind: TwitchColor::Turbo,
@@ -365,9 +365,6 @@ impl From<TwitchColor> for RGB {
 }
 
 /// A utility method that returns an array of [TwitchColor]s mapped to its corresponding [RGB]
-///
-/// [TwitchColor]: ./enum.TwitchColor.html
-/// [RGB]: ./struct.RGB.html
 pub const fn twitch_colors() -> [(TwitchColor, RGB); 15] {
     use TwitchColor::*;
     [

--- a/src/twitch/emotes.rs
+++ b/src/twitch/emotes.rs
@@ -98,7 +98,7 @@ mod tests {
         ];
 
         for (input, expect) in inputs {
-            let emotes = Emotes::parse(&input).collect::<Vec<_>>();
+            let emotes = Emotes::parse(input).collect::<Vec<_>>();
             assert_eq!(emotes.len(), expect.len());
             assert_eq!(emotes, *expect);
         }

--- a/src/twitch/userconfig.rs
+++ b/src/twitch/userconfig.rs
@@ -38,9 +38,7 @@ pub struct UserConfig {
 }
 
 impl UserConfig {
-    /// Create a builder to make a [Config]
-    ///
-    /// [Config]: ./struct.UserConfig.html
+    /// Create a builder to make a [UserConfig]
     pub fn builder() -> UserConfigBuilder {
         UserConfigBuilder::default()
     }
@@ -52,8 +50,6 @@ impl UserConfig {
 }
 
 /// User config error returned by the [UserConfigBuilder]
-///
-/// [UserConfigBuilder]: ./struct.UserConfigBuilder.html
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum UserConfigError {
@@ -82,8 +78,6 @@ impl std::fmt::Display for UserConfigError {
 impl std::error::Error for UserConfigError {}
 
 /// Builder for making a [UserConfig]
-///
-/// [UserConfig]: ./struct.UserConfig.html
 #[derive(Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UserConfigBuilder {
@@ -127,9 +121,9 @@ impl UserConfigBuilder {
 
     /// Enables all of the capabilities.
     ///
-    /// This is just a shortcut for enabling all of the Capabilities listed [here][here].
+    /// This is just a shortcut for enabling all of the Capabilities listed [here].
     ///
-    /// [here]: ./enum.Capability.html
+    /// [here]: Capability
     pub fn enable_all_capabilities(self) -> Self {
         self.capabilities(&[
             Capability::Membership,
@@ -144,7 +138,7 @@ impl UserConfigBuilder {
     ///
     /// If the anonymous `name` OR `token` is used without the other matching one this will return an [error].
     ///
-    /// [error]: ./enum.UserConfigError.html
+    /// [error]: UserConfigError
     pub fn build(self) -> Result<UserConfig, UserConfigError> {
         let name = self
             .name

--- a/src/twitch/userconfig.rs
+++ b/src/twitch/userconfig.rs
@@ -143,12 +143,12 @@ impl UserConfigBuilder {
         let name = self
             .name
             .filter(|s| validate_name(s))
-            .ok_or_else(|| UserConfigError::InvalidName)?;
+            .ok_or(UserConfigError::InvalidName)?;
 
         let token = self
             .token
             .filter(|s| validate_token(s))
-            .ok_or_else(|| UserConfigError::InvalidToken)?;
+            .ok_or(UserConfigError::InvalidToken)?;
 
         match (name.as_str(), token.as_str()) {
             (crate::JUSTINFAN1234, crate::JUSTINFAN1234) => {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -41,17 +41,17 @@ impl<'a> Validator for IrcMessage<'a> {
     fn expect_nick(&self) -> Result<MaybeOwnedIndex, MessageError> {
         self.prefix
             .and_then(|p| p.nick_index())
-            .ok_or_else(|| MessageError::ExpectedNick)
+            .ok_or(MessageError::ExpectedNick)
     }
 
     fn expect_arg(&self, nth: usize) -> Result<&str, MessageError> {
         self.nth_arg(nth)
-            .ok_or_else(|| MessageError::ExpectedArg { pos: nth })
+            .ok_or(MessageError::ExpectedArg { pos: nth })
     }
 
     fn expect_arg_index(&self, nth: usize) -> Result<MaybeOwnedIndex, MessageError> {
         self.nth_arg_index(nth)
-            .ok_or_else(|| MessageError::ExpectedArg { pos: nth })
+            .ok_or(MessageError::ExpectedArg { pos: nth })
     }
 
     fn expect_data(&self) -> Result<&str, MessageError> {
@@ -59,6 +59,6 @@ impl<'a> Validator for IrcMessage<'a> {
     }
 
     fn expect_data_index(&self) -> Result<MaybeOwnedIndex, MessageError> {
-        self.data.ok_or_else(|| MessageError::ExpectedData)
+        self.data.ok_or(MessageError::ExpectedData)
     }
 }

--- a/src/writer/async_writer.rs
+++ b/src/writer/async_writer.rs
@@ -56,7 +56,7 @@ where
         }
     }
 
-    /// Encode this `Encodable` message to the writer.
+    /// Encode this [Encodable] message to the writer.
     pub async fn encode<M>(&mut self, msg: M) -> io::Result<()>
     where
         M: Encodable + Send + Sync,
@@ -71,7 +71,7 @@ where
         Ok(())
     }
 
-    /// Encode a slice of `Encodable` messages to the writer.
+    /// Encode a slice of [Encodable] messages to the writer.
     pub async fn encode_many<'a, I, M>(&mut self, msgs: I) -> io::Result<()>
     where
         I: IntoIterator<Item = &'a M> + Send + Sync + 'a,

--- a/src/writer/mpsc_writer.rs
+++ b/src/writer/mpsc_writer.rs
@@ -9,7 +9,9 @@ use std::{
 
 /// A mpsc-based writer.
 ///
-/// This can be used both a `std::io::Write` instance and a `AsyncWrite` instance.
+/// This can be used both a [std::io::Write] instance and an [AsyncWrite][async-write] instance.
+///
+/// [async-write]: futures_lite::AsyncWrite
 pub struct MpscWriter {
     buf: Vec<u8>,
     channel: crate::channel::Sender<Box<[u8]>>,


### PR DESCRIPTION
This breaks the semver because 'connector::twitch()` must return an error now.

Previously it could panic, and thats not nice.

This also switches the docs to use intradoc links