### PR TITLE
add kind_raw field to Badge

### DIFF
--- a/src/twitch/badge.rs
+++ b/src/twitch/badge.rs
@@ -40,6 +40,10 @@ pub enum BadgeKind<'a> {
 pub struct Badge<'a> {
     /// The kind of the Badge
     pub kind: BadgeKind<'a>,
+    /// The &str representation of the BadgeKind
+    /// In case of BadgeKind::Unknown, this is the same value
+    /// as BadgeKind::Unknown(badge)
+    pub kind_raw: &'a str,
     /// Any associated data with the badge
     ///
     /// May be:
@@ -55,7 +59,8 @@ impl<'a> Badge<'a> {
     pub fn parse(input: &'a str) -> Option<Badge<'a>> {
         use BadgeKind::*;
         let mut iter = input.split('/');
-        let kind = match iter.next()? {
+        let kind_raw =iter.next()?;
+        let kind = match kind_raw {
             "admin" => Admin,
             "bits" => Bits,
             "broadcaster" => Broadcaster,
@@ -70,11 +75,62 @@ impl<'a> Badge<'a> {
             badge => Unknown(badge),
         };
 
-        iter.next().map(|data| Badge { kind, data })
+        iter.next().map(|data| Badge { kind, kind_raw, data })
     }
 }
 
 /// Metadata to the chat badges
 pub type BadgeInfo<'a> = Badge<'a>;
 
-// TODO tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_known_badges() {
+        // ("input", expected value)
+        const BADGE_KINDS: &'static [(&'static str, BadgeKind<'static>)] = &[
+            ("admin", BadgeKind::Admin),
+            ("bits", BadgeKind::Bits),
+            ("broadcaster", BadgeKind::Broadcaster),
+            ("global_mod", BadgeKind::GlobalMod),
+            ("moderator", BadgeKind::Moderator),
+            ("subscriber", BadgeKind::Subscriber),
+            ("staff", BadgeKind::Staff),
+            ("turbo", BadgeKind::Turbo),
+            ("premium", BadgeKind::Premium),
+            ("vip", BadgeKind::VIP),
+            ("partner", BadgeKind::Partner),
+            ("unknown", BadgeKind::Unknown("unknown"))
+        ];
+
+        for (raw, kind) in BADGE_KINDS {
+            let badge_str = format!("{}/0", raw);
+            let badge = Badge::parse(&badge_str)
+                .expect("Malformed badge test");
+
+            assert_eq!(badge.kind, *kind);
+            assert_eq!(badge.kind_raw, *raw);
+            assert_eq!(badge.data, "0");
+        }
+    }
+
+    #[test]
+    fn parse_unknown() {
+        let badge_str = "this_badge_does_not_exist/0";
+        let badge = Badge::parse(badge_str);
+        assert_eq!(badge, Some(Badge {
+            kind: BadgeKind::Unknown("this_badge_does_not_exist"),
+            kind_raw: "this_badge_does_not_exist",
+            data: "0"
+        }))
+    }
+
+    #[test]
+    fn parse_invalid() {
+        let badge_str = "this_badge_is_invalid";
+        let badge = Badge::parse(badge_str);
+        assert_eq!(badge, None)
+    }
+
+}


### PR DESCRIPTION
When loading the actual image of the badge, we need the name of the badge. One could write code to match on the `BadgeKind` and return the name, but this is unnecessary since this information already exists. This feature just exposes the raw name. In terms of performance, this change should be negligible.