### PR TITLE
Use `BagdeKind::VIP` in `Privmsg::is_vip` instead of `BagdeKind::Broadcaster`

### DIFF
--- a/src/messages/privmsg.rs
+++ b/src/messages/privmsg.rs
@@ -174,7 +174,7 @@ impl<'a> Privmsg<'a> {
 
     /// Whether the user sending this message was a vip
     pub fn is_vip(&self) -> bool {
-        self.contains_badge(BadgeKind::Broadcaster)
+        self.contains_badge(BadgeKind::VIP)
     }
 
     /// Whether the user sending this message was a susbcriber


### PR DESCRIPTION
## Description
`Privmsg::is_vip` used to check for `BadgeKind::Broadcaster`, but `is_vip` describes to whether the message is sent by Twitch Channel VIP. It closes #232.

## Type of Change

This change fixes the prior incorrect behaviour of `Privmsg::is_vip` by now checking for `BadgeKind::VIP` instead. The behaviour change is a fix and therefore stable.

## How Has This Been Tested?

Before, messages by VIPs of a Twitch Channel would cause `msg.is_vip()` to evaluate to `false`, while I expected `true`. Once the code change was applied, the expression evaluated to `true` for VIPs and `false` for users without the VIP badge.